### PR TITLE
Move stivale in separate headers.

### DIFF
--- a/STIVALE2.md
+++ b/STIVALE2.md
@@ -176,7 +176,7 @@ Omitting this tag will make the bootloader default to a CGA-compatible text mode
 if supported.
 
 ```c
-struct stivale2_hdr_tag_framebuffer {
+struct stivale2_header_tag_framebuffer {
     uint64_t identifier;          // Identifier: 0x3ecc1bc43d0f7971
     uint64_t next;
     uint16_t framebuffer_width;   // If all values are set to 0

--- a/stage2/Makefile
+++ b/stage2/Makefile
@@ -18,6 +18,7 @@ INTERNAL_CFLAGS =  \
 	-mno-sse \
 	-mno-sse2 \
 	-I. \
+	-I.. \
 	-Wno-address-of-packed-member
 
 LDFLAGS = -flto -Os

--- a/stage2/protos/stivale.c
+++ b/stage2/protos/stivale.c
@@ -16,38 +16,7 @@
 #include <drivers/pic.h>
 #include <fs/file.h>
 #include <mm/vmm64.h>
-
-struct stivale_header {
-    uint64_t stack;
-    uint16_t flags;
-    uint16_t framebuffer_width;
-    uint16_t framebuffer_height;
-    uint16_t framebuffer_bpp;
-    uint64_t entry_point;
-} __attribute__((packed));
-
-struct stivale_module {
-    uint64_t begin;
-    uint64_t end;
-    char     string[128];
-    uint64_t next;
-} __attribute__((packed));
-
-struct stivale_struct {
-    uint64_t cmdline;
-    uint64_t memory_map_addr;
-    uint64_t memory_map_entries;
-    uint64_t framebuffer_addr;
-    uint16_t framebuffer_pitch;
-    uint16_t framebuffer_width;
-    uint16_t framebuffer_height;
-    uint16_t framebuffer_bpp;
-    uint64_t rsdp;
-    uint64_t module_count;
-    uint64_t modules;
-    uint64_t epoch;
-    uint64_t flags;       // bit 0: 1 if booted with BIOS, 0 if booted with UEFI
-} __attribute__((packed));
+#include <stivale/stivale.h>
 
 #define KASLR_SLIDE_BITMASK 0x03FFFF000u
 

--- a/stage2/protos/stivale2.c
+++ b/stage2/protos/stivale2.c
@@ -18,103 +18,7 @@
 #include <lib/term.h>
 #include <drivers/pic.h>
 #include <fs/file.h>
-
-struct stivale2_tag {
-    uint64_t identifier;
-    uint64_t next;
-} __attribute__((packed));
-
-struct stivale2_header {
-    uint64_t entry_point;
-    uint64_t stack;
-    uint64_t flags;
-    uint64_t tags;
-} __attribute__((packed));
-
-#define STIVALE2_HDR_TAG_FRAMEBUFFER_ID 0x3ecc1bc43d0f7971
-
-struct stivale2_hdr_tag_framebuffer {
-    struct stivale2_tag tag;
-    uint16_t framebuffer_width;
-    uint16_t framebuffer_height;
-    uint16_t framebuffer_bpp;
-} __attribute__((packed));
-
-#define STIVALE2_HDR_TAG_5LV_PAGING_ID 0x932f477032007e8f
-
-struct stivale2_struct {
-    char bootloader_brand[64];
-    char bootloader_version[64];
-    uint64_t tags;
-} __attribute__((packed));
-
-#define STIVALE2_STRUCT_TAG_CMDLINE_ID 0xe5e76a1b4597a781
-
-struct stivale2_struct_tag_cmdline {
-    struct stivale2_tag tag;
-    uint64_t cmdline;
-} __attribute__((packed));
-
-#define STIVALE2_STRUCT_TAG_MEMMAP_ID 0x2187f79e8612de07
-
-struct stivale2_mmap_entry {
-    uint64_t base;
-    uint64_t length;
-    uint32_t type;
-    uint32_t unused;
-} __attribute__((packed));
-
-struct stivale2_struct_tag_memmap {
-    struct stivale2_tag tag;
-    uint64_t entries;
-    struct stivale2_mmap_entry memmap[];
-} __attribute__((packed));
-
-#define STIVALE2_STRUCT_TAG_FRAMEBUFFER_ID 0x506461d2950408fa
-
-struct stivale2_struct_tag_framebuffer {
-    struct stivale2_tag tag;
-    uint64_t framebuffer_addr;
-    uint16_t framebuffer_width;
-    uint16_t framebuffer_height;
-    uint16_t framebuffer_pitch;
-    uint16_t framebuffer_bpp;
-} __attribute__((packed));
-
-#define STIVALE2_STRUCT_TAG_MODULES_ID 0x4b6fe466aade04ce
-
-struct stivale2_module {
-    uint64_t begin;
-    uint64_t end;
-    char     string[128];
-} __attribute__((packed));
-
-struct stivale2_struct_tag_modules {
-    struct stivale2_tag tag;
-    uint64_t module_count;
-    struct stivale2_module modules[];
-} __attribute__((packed));
-
-#define STIVALE2_STRUCT_TAG_RSDP_ID 0x9e1786930a375e78
-
-struct stivale2_struct_tag_rsdp {
-    struct stivale2_tag tag;
-    uint64_t rsdp;
-} __attribute__((packed));
-
-#define STIVALE2_STRUCT_TAG_EPOCH_ID 0x566a7bed888e1407
-
-struct stivale2_struct_tag_epoch {
-    struct stivale2_tag tag;
-    uint64_t epoch;
-} __attribute__((packed));
-
-#define STIVALE2_STRUCT_TAG_FIRMWARE_ID 0x359d837855e3858c
-
-struct stivale2_struct_tag_firmware {
-    struct stivale2_tag tag;
-    uint64_t flags;
-} __attribute__((packed));
+#include <stivale/stivale2.h>
 
 #define KASLR_SLIDE_BITMASK 0x03FFFF000u
 
@@ -362,7 +266,7 @@ void stivale2_load(char *cmdline, int boot_drive) {
     // Create framebuffer struct tag
     //////////////////////////////////////////////
     {
-    struct stivale2_hdr_tag_framebuffer *hdrtag = get_tag(&stivale2_hdr, STIVALE2_HDR_TAG_FRAMEBUFFER_ID);
+    struct stivale2_header_tag_framebuffer *hdrtag = get_tag(&stivale2_hdr, STIVALE2_HEADER_TAG_FRAMEBUFFER_ID);
 
     term_deinit();
 
@@ -407,7 +311,7 @@ void stivale2_load(char *cmdline, int boot_drive) {
     }
 
     // Check if 5-level paging tag is requesting support
-    bool level5pg_requested = get_tag(&stivale2_hdr, STIVALE2_HDR_TAG_5LV_PAGING_ID) ? true : false;
+    bool level5pg_requested = get_tag(&stivale2_hdr, STIVALE2_HEADER_TAG_5LV_PAGING_ID) ? true : false;
 
     stivale_spinup(bits, level5pg && level5pg_requested,
                    entry_point, &stivale2_struct, stivale2_hdr.stack,

--- a/stivale/stivale.h
+++ b/stivale/stivale.h
@@ -1,0 +1,44 @@
+#ifndef __STIVALE__STIVALE_H__
+#define __STIVALE__STIVALE_H__
+
+#include <stdint.h>
+
+/* --- Header --------------------------------------------------------------- */
+/*  Information passed from the kernel to the bootloader                      */
+
+struct stivale_header {
+    uint64_t stack;
+    uint16_t flags;
+    uint16_t framebuffer_width;
+    uint16_t framebuffer_height;
+    uint16_t framebuffer_bpp;
+    uint64_t entry_point;
+} __attribute__((packed));
+
+/* --- Struct --------------------------------------------------------------- */
+/*  Information passed from the bootloader to the kernel                      */
+
+struct stivale_module {
+    uint64_t begin;
+    uint64_t end;
+    char string[128];
+    uint64_t next;
+} __attribute__((packed));
+
+struct stivale_struct {
+    uint64_t cmdline;
+    uint64_t memory_map_addr;
+    uint64_t memory_map_entries;
+    uint64_t framebuffer_addr;
+    uint16_t framebuffer_pitch;
+    uint16_t framebuffer_width;
+    uint16_t framebuffer_height;
+    uint16_t framebuffer_bpp;
+    uint64_t rsdp;
+    uint64_t module_count;
+    uint64_t modules;
+    uint64_t epoch;
+    uint64_t flags; // bit 0: 1 if booted with BIOS, 0 if booted with UEFI
+} __attribute__((packed));
+
+#endif

--- a/stivale/stivale2.h
+++ b/stivale/stivale2.h
@@ -1,0 +1,115 @@
+#ifndef __STIVALE__STIVALE2_H__
+#define __STIVALE__STIVALE2_H__
+
+#include <stdint.h>
+
+struct stivale2_tag {
+    uint64_t identifier;
+    uint64_t next;
+} __attribute__((packed));
+
+/* --- Header --------------------------------------------------------------- */
+/*  Information passed from the kernel to the bootloader                      */
+
+struct stivale2_header {
+    uint64_t entry_point;
+    uint64_t stack;
+    uint64_t flags;
+    uint64_t tags;
+} __attribute__((packed));
+
+#define STIVALE2_HEADER_TAG_FRAMEBUFFER_ID 0x3ecc1bc43d0f7971
+
+struct stivale2_header_tag_framebuffer {
+    struct stivale2_tag tag;
+    uint16_t framebuffer_width;
+    uint16_t framebuffer_height;
+    uint16_t framebuffer_bpp;
+} __attribute__((packed));
+
+#define STIVALE2_HEADER_TAG_5LV_PAGING_ID 0x932f477032007e8f
+
+/* --- Struct --------------------------------------------------------------- */
+/*  Information passed from the bootloader to the kernel                      */
+
+struct stivale2_struct {
+#define STIVALE2_BOOTLOADER_BRAND_SIZE 64
+    char bootloader_brand[STIVALE2_BOOTLOADER_BRAND_SIZE];
+
+#define STIVALE2_BOOTLOADER_VERSION_SIZE 64
+    char bootloader_version[STIVALE2_BOOTLOADER_VERSION_SIZE];
+
+    uint64_t tags;
+} __attribute__((packed));
+
+#define STIVALE2_STRUCT_TAG_CMDLINE_ID 0xe5e76a1b4597a781
+
+struct stivale2_struct_tag_cmdline {
+    struct stivale2_tag tag;
+    uint64_t cmdline;
+} __attribute__((packed));
+
+#define STIVALE2_STRUCT_TAG_MEMMAP_ID 0x2187f79e8612de07
+
+struct stivale2_mmap_entry {
+    uint64_t base;
+    uint64_t length;
+    uint32_t type;
+    uint32_t unused;
+} __attribute__((packed));
+
+struct stivale2_struct_tag_memmap {
+    struct stivale2_tag tag;
+    uint64_t entries;
+    struct stivale2_mmap_entry memmap[];
+} __attribute__((packed));
+
+#define STIVALE2_STRUCT_TAG_FRAMEBUFFER_ID 0x506461d2950408fa
+
+struct stivale2_struct_tag_framebuffer {
+    struct stivale2_tag tag;
+    uint64_t framebuffer_addr;
+    uint16_t framebuffer_width;
+    uint16_t framebuffer_height;
+    uint16_t framebuffer_pitch;
+    uint16_t framebuffer_bpp;
+} __attribute__((packed));
+
+#define STIVALE2_STRUCT_TAG_MODULES_ID 0x4b6fe466aade04ce
+
+struct stivale2_module {
+    uint64_t begin;
+    uint64_t end;
+
+#define STIVALE2_MODULE_STRING_SIZE 128
+    char string[STIVALE2_MODULE_STRING_SIZE];
+} __attribute__((packed));
+
+struct stivale2_struct_tag_modules {
+    struct stivale2_tag tag;
+    uint64_t module_count;
+    struct stivale2_module modules[];
+} __attribute__((packed));
+
+#define STIVALE2_STRUCT_TAG_RSDP_ID 0x9e1786930a375e78
+
+struct stivale2_struct_tag_rsdp {
+    struct stivale2_tag tag;
+    uint64_t rsdp;
+} __attribute__((packed));
+
+#define STIVALE2_STRUCT_TAG_EPOCH_ID 0x566a7bed888e1407
+
+struct stivale2_struct_tag_epoch {
+    struct stivale2_tag tag;
+    uint64_t epoch;
+} __attribute__((packed));
+
+#define STIVALE2_STRUCT_TAG_FIRMWARE_ID 0x359d837855e3858c
+
+struct stivale2_struct_tag_firmware {
+    struct stivale2_tag tag;
+    uint64_t flags;
+} __attribute__((packed));
+
+#endif


### PR DESCRIPTION
Making them easier to use when including "limine" has a submodule.
Also renamed stivale2_hdr_tag_framebuffer to stivale2_header_tag_framebuffer.
This makes it more consistent with other declaration in stivale2.