### PR TITLE
Improve performance on TCG, part 1

### DIFF
--- a/stage23/lib/bmp.c
+++ b/stage23/lib/bmp.c
@@ -29,44 +29,9 @@ struct bmp_header {
 } __attribute__((packed));
 
 struct bmp_local {
-    uint8_t  *image;
-    uint32_t  pitch;
     struct bmp_header header;
 };
 
-static uint32_t get_pixel(struct image *this, int x, int y) {
-    struct bmp_local *local = this->local;
-    struct bmp_header *header = &local->header;
-
-    switch (this->type) {
-        case IMAGE_TILED: {
-            x %= header->bi_width;
-            y %= header->bi_height;
-            break;
-        }
-        case IMAGE_CENTERED: {
-            x -= this->x_displacement;
-            y -= this->y_displacement;
-            if (x < 0 || y < 0 || x >= this->x_size || y >= this->y_size)
-                return this->back_colour;
-            break;
-        }
-        case IMAGE_STRETCHED: {
-            x = (x * this->old_x_size) / this->x_size;
-            y = (y * this->old_y_size) / this->y_size;
-            break;
-        }
-    }
-
-    size_t pixel_offset = local->pitch * (header->bi_height - y - 1) + x * (header->bi_bpp / 8);
-
-    // TODO: Perhaps use masks here, they're there for a reason
-    uint32_t composite = 0;
-    for (int i = 0; i < header->bi_bpp / 8; i++)
-        composite |= (uint32_t)local->image[pixel_offset + i] << (i * 8);
-
-    return composite;
-}
 
 int bmp_open_image(struct image *image, struct file_handle *file) {
     struct bmp_header header;
@@ -75,22 +40,22 @@ int bmp_open_image(struct image *image, struct file_handle *file) {
     if (memcmp(&header.bf_signature, "BM", 2) != 0)
         return -1;
 
-    // We don't support bpp lower than 8
-    if (header.bi_bpp < 8)
+    if ((header.bi_bpp < 8) | ((header.bi_bpp % 8) != 0))
         return -1;
 
     struct bmp_local *local = ext_mem_alloc(sizeof(struct bmp_local));
 
-    local->image = ext_mem_alloc(header.bf_size);
-    fread(file, local->image, header.bf_offset, header.bf_size);
+    image->img = ext_mem_alloc(header.bf_size);
+    fread(file, image->img, header.bf_offset, header.bf_size);
 
-    local->pitch  = ALIGN_UP(header.bi_width * header.bi_bpp, 32) / 8;
     local->header = header;
 
-    image->x_size    = header.bi_width;
-    image->y_size    = header.bi_height;
-    image->get_pixel = get_pixel;
-    image->local     = local;
-
+    image->x_size     = header.bi_width;
+    image->y_size     = header.bi_height;
+    image->pitch      = ALIGN_UP(header.bi_width * header.bi_bpp, 32) / 8;
+    image->local      = local;
+    image->bpp        = header.bi_bpp;
+    image->img_width  = header.bi_width;
+    image->img_height = header.bi_height;
     return 0;
 }

--- a/stage23/lib/image.c
+++ b/stage23/lib/image.c
@@ -17,9 +17,6 @@ void image_make_centered(struct image *image, int frame_x_size, int frame_y_size
 void image_make_stretched(struct image *image, int new_x_size, int new_y_size) {
     image->type = IMAGE_STRETCHED;
 
-    image->old_x_size = image->x_size;
-    image->old_y_size = image->y_size;
-
     image->x_size = new_x_size;
     image->y_size = new_y_size;
 }

--- a/stage23/lib/image.h
+++ b/stage23/lib/image.h
@@ -9,6 +9,13 @@ struct image {
     int x_size;
     int y_size;
     int type;
+
+
+    uint8_t *img;
+    int bpp;
+    int pitch;
+    int img_width; // x_size = scaled size, img_width = bitmap size 
+    int img_height;
     union {
         struct {
             int x_displacement;
@@ -20,7 +27,6 @@ struct image {
         };
     };
     uint32_t back_colour;
-    uint32_t (*get_pixel)(struct image *this, int x, int y);
     void *local;
 };
 


### PR DESCRIPTION
Make the initial image load and screen clearing faster, especially when running without hardware virtualization.