### PR TITLE
readline: exclude the non-ctrl case from checks

### DIFF
--- a/stage23/lib/readline.c
+++ b/stage23/lib/readline.c
@@ -37,11 +37,11 @@ int getchar_internal(uint8_t scancode, uint8_t ascii) {
             return GETCHAR_ESCAPE;
 
         // special case checks for C-[pnfb]
-#define CTRL_CHECK(ch, key)             \
-            if ((ascii | 0x60) == ch) { \
-                return key;             \
-            } else {                    \
-                break;                  \
+#define CTRL_CHECK(ch, key)                            \
+            if ((ascii | 0x60) == ch && ascii != ch) { \
+                return key;                            \
+            } else {                                   \
+                break;                                 \
             }
         case 0x19:
             CTRL_CHECK('p', GETCHAR_CURSOR_UP);
@@ -76,10 +76,9 @@ int getchar_internal(uint8_t scancode, uint8_t ascii) {
             return GETCHAR_ESCAPE;
 
         // special case checks for C-[pnfb]
-        // EFI for some reason reports scancode zero if Ctrl is held
-#define CTRL_CHECK(ch, key)             \
-            if ((ascii | 0x60) == ch) { \
-                return key;             \
+#define CTRL_CHECK(ch, key)                            \
+            if ((ascii | 0x60) == ch && ascii != ch) { \
+                return key;                            \
             }
         case 0:
             CTRL_CHECK('p', GETCHAR_CURSOR_UP);


### PR DESCRIPTION
Honestly, all of this is hacky, somehow people implementing these APIs
never bothered to put modifiers in some other register to be returned.
The EFI people got a whole struct dedicated to returning what key is
pressed, and didn't even put the modifiers in it.

EFI actually did implement this with EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL,
the returned struct holds the modifier. I can implement this using that
protocol and int 16/AH=01h at a later date.