### PR TITLE
gterm+bmp: Fix and image sanity check

### DIFF
--- a/stage23/lib/bmp.c
+++ b/stage23/lib/bmp.c
@@ -40,7 +40,10 @@ int bmp_open_image(struct image *image, struct file_handle *file) {
     if (memcmp(&header.bf_signature, "BM", 2) != 0)
         return -1;
 
-    if ((header.bi_bpp < 8) | ((header.bi_bpp % 8) != 0))
+    if ((header.bi_bpp != 32) && (header.bi_bpp != 24))
+        return -1;
+
+    if (header.bi_compression)
         return -1;
 
     struct bmp_local *local = ext_mem_alloc(sizeof(struct bmp_local));

--- a/stage23/lib/gterm.c
+++ b/stage23/lib/gterm.c
@@ -156,7 +156,7 @@ __attribute__((always_inline)) static inline void genloop(int xstart, int xend, 
     // so you can set x = xstart * ratio, and increment by ratio at each iteration
     case IMAGE_STRETCHED:
         for (int y = ystart; y < yend; y++) {
-            int img_y = y * img_width / gterm_width; // calculate Y with full precision
+            int img_y = (y * img_height) / gterm_height; // calculate Y with full precision
             int off = img_pitch * (img_height - 1 - img_y);
             int canvas_off = gterm_width * y, fb_off = gterm_pitch / 4 * y;
 


### PR DESCRIPTION
BMP supports RLE-compressed and packed images, which Limine currently doesn't support. Fail instead of misinterpreting data.