### PR TITLE
Make sure the requested stack is aligned at word boundary

### DIFF
--- a/stage23/protos/stivale.c
+++ b/stage23/protos/stivale.c
@@ -174,6 +174,12 @@ void stivale_load(char *config, char *cmdline) {
         print("stivale: Requested stack at: %X\n", stivale_hdr.stack);
     }
 
+    // Check if the requested stack is correctly aligned at a word
+    // boundary (8 bytes on x64 and 4 bytes on x86).
+    if ((stivale_hdr.stack & (sizeof(size_t) - 1)) != 0) {
+        print("warn: Requested stack is not aligned at word boundary.");
+    }
+
     stivale_struct.module_count = 0;
     uint64_t *prev_mod_ptr = &stivale_struct.modules;
     for (int i = 0; ; i++) {

--- a/stage23/protos/stivale2.c
+++ b/stage23/protos/stivale2.c
@@ -191,6 +191,12 @@ failed_to_load_header_section:
         print("stivale2: Requested stack at: %X\n", stivale2_hdr.stack);
     }
 
+    // Check if the requested stack is correctly aligned at a word
+    // boundary (8 bytes on x64 and 4 bytes on x86).
+    if ((stivale2_hdr.stack & (sizeof(size_t) - 1)) != 0) {
+        print("warn: Requested stack is not aligned at word boundary.");
+    }
+
     strcpy(stivale2_struct.bootloader_brand, "Limine");
     strcpy(stivale2_struct.bootloader_version, LIMINE_VERSION);
 


### PR DESCRIPTION
This pull request adds a check that the requested stack is aligned at a word boundary. If the stack is not aligned it makes things slower and also if you want to access a variable on stack it must be aligned if you are using rust.

Signed-off-by: Andy-Python-Programmer <andypythonappdeveloper@gmail.com>