### PR TITLE
Add limine-install to .gitignore on latest-binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+limine-install


### PR DESCRIPTION
This file is generated by the Makefile, and as such, marks the repository as dirty after building when using the VSCode git functionality.
![image](https://user-images.githubusercontent.com/2322546/127478486-32432c65-7dee-4624-aacf-ce85a44dbeb6.png)
I assume this will make it drop down into the `v2.0-branch-binary` branch too
