### PR TITLE
PE32/PE64 Support

### DIFF
--- a/stage23/lib/elf.h
+++ b/stage23/lib/elf.h
@@ -17,7 +17,8 @@ struct elf_range {
     uint64_t permissions;
 };
 
-int elf_bits(uint8_t *elf);
+bool elf_detect(uint8_t *elf);
+int elf_bits(uint8_t *elf); // Assumes the ELF is valid
 
 int elf64_load(uint8_t *elf, uint64_t *entry_point, uint64_t *top, uint64_t *_slide, uint32_t alloc_type, bool kaslr, bool use_paddr, struct elf_range **ranges, uint64_t *ranges_count);
 int elf64_load_section(uint8_t *elf, void *buffer, const char *name, size_t limit, uint64_t slide);

--- a/stage23/lib/pe.c
+++ b/stage23/lib/pe.c
@@ -1,0 +1,233 @@
+#include <stdbool.h>
+#include <lib/blib.h>
+#include <lib/libc.h>
+#include <lib/pe.h>
+#include <lib/print.h>
+#include <mm/pmm.h>
+
+#define FIXED_HIGHER_HALF_OFFSET_64 ((uint64_t)0xffffffff80000000)
+
+#define MZ_MAGIC 0x5a4d
+
+#define PE_MAGIC         0x00004550
+#define PE_MACHINE_I386  0x14c
+#define PE_MACHINE_AMD64 0x8664
+
+#define PE_OPT_MAGIC_PE32 0x10b
+#define PE_OPT_MAGIC_PE64 0x20b
+
+#define PE_SEC_UNINIT_DATA (1 << 7)
+
+static bool pe_validate(uint8_t *pe, bool is_64, bool warn) {
+    struct pe_dos_header *dos_hdr = (struct pe_dos_header *) pe;
+    if (dos_hdr->magic != MZ_MAGIC) {
+        if (warn)
+            print("pe: Invalid MS-DOS MZ header magic\n");
+        return false;
+    }
+
+    struct pe_header *pe_hdr = (struct pe_header *) (pe + dos_hdr->new_header_off);
+    if (pe_hdr->magic != PE_MAGIC) {
+        print("pe: Invalid PE header magic\n");
+        return false;
+    }
+
+    if (is_64) {
+        if (pe_hdr->machine != PE_MACHINE_AMD64) {
+            if (warn)
+                print("pe: Invalid PE header machine (must be AMD64)\n");
+            return false;
+        }
+        if (pe_hdr->optional_header_size == 0) {
+            if (warn)
+                print("pe: No optional header");
+            return false;
+        }
+        struct pe64_optional_header *pe64_opt_hdr = (struct pe64_optional_header *) (pe_hdr + 1);
+        if (pe64_opt_hdr->magic != PE_OPT_MAGIC_PE64) {
+            if (warn)
+                print("pe: Invalid PE optional header magic (must be PE64)\n");
+            return false;
+        }
+    } else {
+        if (pe_hdr->machine != PE_MACHINE_I386) {
+            if (warn)
+                print("pe: Invalid PE header machine (must be i386)\n");
+            return false;
+        }
+        if (pe_hdr->optional_header_size == 0) {
+            if (warn)
+                print("pe: No optional header\n");
+            return false;
+        }
+        struct pe32_optional_header *pe32_opt_hdr = (struct pe32_optional_header *) (pe_hdr + 1);
+        if (pe32_opt_hdr->magic != PE_OPT_MAGIC_PE32) {
+            if (warn)
+                print("pe: Invalid PE optional header magic (must be PE32)\n");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+int pe_bits(uint8_t *pe) {
+    /*
+        Basically, first validate the file considering the file is
+        32 bit. If it returns positive, then the file is 32 bit.
+        Otherwise, validate it as if it was a 64 bit one. If that
+        doesn't work either, give up.
+    */
+    bool result = pe_validate(pe, false, false);
+    if (result == true) {
+        return 32;
+    }
+    result = pe_validate(pe, true, false);
+    if (result == true) {
+        return 64;
+    }
+    return -1;
+}
+
+int pe64_load(uint8_t *pe, uint64_t *entry_point, uint64_t *top, uint64_t *_slide, uint32_t alloc_type, bool kaslr) {
+    (void) _slide;
+    if (!pe_validate(pe, true, true)) {
+        return 1;
+    }
+
+    if (kaslr)
+        panic("pe: Relocations not supported yet");
+
+    struct pe_dos_header *dos_hdr = (struct pe_dos_header *) pe;
+    struct pe_header *pe_hdr = (struct pe_header *) (pe + dos_hdr->new_header_off);
+    struct pe64_optional_header *pe64_opt_hdr = (struct pe64_optional_header *) (pe_hdr + 1);
+
+    uint16_t sections = pe_hdr->section_amount;
+    uint64_t image_base = pe64_opt_hdr->image_base;
+    uint64_t physical_base = image_base;
+    if (image_base & (1ULL << 63))
+        physical_base -= FIXED_HIGHER_HALF_OFFSET_64;
+
+    *entry_point = image_base + pe64_opt_hdr->entry_point_addr;
+
+    struct pe_section_header *section = (struct pe_section_header *) ((uint8_t *) pe64_opt_hdr + pe_hdr->optional_header_size);
+
+    uint64_t this_top = 0;
+    if (top)
+        *top = this_top;
+
+    for (uint16_t i = 0; i < sections; i++) {
+        if (!memmap_alloc_range(physical_base + section->virtual_addr, section->virtual_size, alloc_type, true, false, false, false)) {
+            panic("pe: Could not copy section %S", (const char *) &section->name, 8);
+        }
+
+        if (section->characteristics & PE_SEC_UNINIT_DATA)
+            memset((void *) (uintptr_t) physical_base + section->virtual_addr, 0, section->virtual_size);
+        else
+            memcpy((void *) (uintptr_t) physical_base + section->virtual_addr, pe + section->data_ptr, section->virtual_size);
+
+        this_top = physical_base + section->virtual_addr;
+        if (top) {
+            if (this_top > *top)
+                *top = this_top;
+        }
+
+        section++;
+    }
+
+    return 0;
+}
+
+int pe64_load_section(uint8_t *pe, void *buffer, const char *name, size_t limit, uint64_t slide) {
+    if (!pe_validate(pe, true, true))
+        return 1;
+
+    if (slide)
+        panic("pe: Relocations not supported yet");
+
+    struct pe_dos_header *dos_hdr = (struct pe_dos_header *) pe;
+    struct pe_header *pe_hdr = (struct pe_header *) (pe + dos_hdr->new_header_off);
+    struct pe64_optional_header *pe64_opt_hdr = (struct pe64_optional_header *) (pe_hdr + 1);
+
+    uint16_t sections = pe_hdr->section_amount;
+
+    struct pe_section_header *section = (struct pe_section_header *) ((uint8_t *) pe64_opt_hdr + pe_hdr->optional_header_size);
+    for (uint16_t i = 0; i < sections; i++) {
+        if (!strcmp((const char *) &section->name, name)) {
+            if (section->virtual_size > limit)
+                return 3;
+            if (section->virtual_size < limit)
+                return 4;
+            memcpy(buffer, pe + section->data_ptr, limit);
+            return 0;
+        }
+        section++;
+    }
+
+    return 2;
+}
+
+int pe32_load(uint8_t *pe, uint32_t *entry_point, uint32_t *top, uint32_t alloc_type) {
+    if (!pe_validate(pe, false, true))
+        return 1;
+
+    struct pe_dos_header *dos_hdr = (struct pe_dos_header *) pe;
+    struct pe_header *pe_hdr = (struct pe_header *) (pe + dos_hdr->new_header_off);
+    struct pe32_optional_header *pe32_opt_hdr = (struct pe32_optional_header *) (pe_hdr + 1);
+
+    uint16_t sections = pe_hdr->section_amount;
+    uint32_t image_base = pe32_opt_hdr->image_base;
+    
+    *entry_point = image_base + pe32_opt_hdr->entry_point_addr;
+
+    struct pe_section_header *section = (struct pe_section_header *) ((uint8_t *) pe32_opt_hdr + pe_hdr->optional_header_size);
+
+    uint32_t this_top = 0;
+    if (top)
+        *top = 0;
+
+    for (uint16_t i = 0; i < sections; i++) {
+        if (!memmap_alloc_range(image_base + section->virtual_addr, section->virtual_size, alloc_type, true, false, false, false))
+            panic("pe: Could not copy section %S", (const char *) &section->name, 8);
+
+        if (section->characteristics & PE_SEC_UNINIT_DATA)
+            memset((void *) (uintptr_t) image_base + section->virtual_addr, 0, section->virtual_size);
+        else
+            memcpy((void *) (uintptr_t) image_base + section->virtual_addr, pe + section->data_ptr, section->virtual_size);
+
+        this_top = image_base + section->virtual_addr;
+        if (top) {
+            if (this_top > *top)
+                *top = this_top;
+        }
+
+        section++;
+    }
+    return 0;
+}
+
+int pe32_load_section(uint8_t *pe, void *buffer, const char *name, size_t limit) {
+    if (!pe_validate(pe, false, true))
+        return 1;
+
+    struct pe_dos_header *dos_hdr = (struct pe_dos_header *) pe;
+    struct pe_header *pe_hdr = (struct pe_header *) (pe + dos_hdr->new_header_off);
+    struct pe32_optional_header *pe32_opt_hdr = (struct pe32_optional_header *) (pe_hdr + 1);
+
+    uint16_t sections = pe_hdr->section_amount;
+
+    struct pe_section_header *section = (struct pe_section_header *) ((uint8_t *) pe32_opt_hdr + pe_hdr->optional_header_size);
+    for (uint16_t i = 0; i < sections; i++) {
+        if (!strcmp((const char *) &section->name, name)) {
+            if (section->virtual_size > limit)
+                return 3;
+            if (section->virtual_size < limit)
+                return 4;
+            memcpy(buffer, pe + section->data_ptr, limit);
+            return 0;
+        }
+        section++;
+    }
+
+    return 2;
+}

--- a/stage23/lib/pe.h
+++ b/stage23/lib/pe.h
@@ -107,7 +107,7 @@ struct pe64_optional_header {
 struct pe_section_header {
     char name[8];
     union {
-        uint32_t physical_addr;
+        uint32_t physical_addr; // Only valid for object files
         uint32_t virtual_size;
     };
     uint32_t virtual_addr;
@@ -120,10 +120,11 @@ struct pe_section_header {
     uint32_t characteristics;
 } __attribute__((packed));
 
-int pe_bits(uint8_t *pe);
+bool pe_detect(uint8_t *pe);
+int pe_bits(uint8_t *pe); // Assumes the PE is valid
 
-int pe64_load(uint8_t *pe, uint64_t *entry_point, uint64_t *top, uint64_t *_slide, uint32_t alloc_type, bool kaslr);
-int pe64_load_section(uint8_t *pe, void *buffer, const char *name, size_t limit, uint64_t slide);
+int pe64_load(uint8_t *pe, uint64_t *entry_point, uint64_t *top, uint32_t alloc_type);
+int pe64_load_section(uint8_t *pe, void *buffer, const char *name, size_t limit);
 
 int pe32_load(uint8_t *pe, uint32_t *entry_point, uint32_t *top, uint32_t alloc_type);
 int pe32_load_section(uint8_t *pe, void *buffer, const char *name, size_t limit);

--- a/stage23/lib/pe.h
+++ b/stage23/lib/pe.h
@@ -1,0 +1,131 @@
+#ifndef __LIB__PE_H__
+#define __LIB__PE_H__
+
+#include <stddef.h>
+#include <stdint.h>
+
+struct pe_dos_header {
+    uint16_t magic;
+    uint16_t bytes_last_page;
+    uint16_t pages;
+    uint16_t relocations;
+    uint16_t header_size_paragraphs;
+    uint16_t min_extra_paragraphs;
+    uint16_t max_extra_paragraphs;
+    uint16_t init_ss;
+    uint16_t init_sp;
+    uint16_t checksum;
+    uint16_t init_ip;
+    uint16_t init_cs;
+    uint16_t rel_table_off;
+    uint16_t overlay;
+    uint16_t reserved0[4];
+    uint16_t oem_id;
+    uint16_t oem_info;
+    uint16_t reserved1[10];
+    uint32_t new_header_off;
+} __attribute__((packed));
+
+struct pe_header {
+    uint32_t magic;
+    uint16_t machine;
+    uint16_t section_amount;
+    uint32_t timestamp;
+    uint32_t symbol_table_ptr;
+    uint32_t symbol_amount;
+    uint16_t optional_header_size;
+    uint16_t characteristics;
+} __attribute__((packed));
+
+struct pe32_optional_header {
+    uint16_t magic;
+    uint8_t  linker_major_version;
+    uint8_t  linker_minor_version;
+    uint32_t code_size;
+    uint32_t initialized_data_size;
+    uint32_t uninitialized_data_size;
+    uint32_t entry_point_addr;
+    uint32_t code_base;
+    uint32_t data_base;
+    // All of these after, mostly Windows specific
+    uint32_t image_base;
+    uint32_t section_alignment;
+    uint32_t file_alignment;
+    uint16_t os_major_version;
+    uint16_t os_minor_version;
+    uint16_t image_major_version;
+    uint16_t image_minor_version;
+    uint16_t subsystem_major_version;
+    uint16_t subsystem_minor_version;
+    uint32_t win32_version;
+    uint32_t image_size;
+    uint32_t headers_size;
+    uint32_t checksum;
+    uint16_t subsystem;
+    uint16_t dll_characteristics;
+    uint32_t stack_reserve_size;
+    uint32_t stack_commit_size;
+    uint32_t heap_reserve_size;
+    uint32_t heap_commit_size;
+    uint32_t loader_flags;
+    uint32_t rva_amount_sizes;
+} __attribute__((packed));
+
+struct pe64_optional_header {
+    uint16_t magic;
+    uint8_t  linker_major_version;
+    uint8_t  linker_minor_version;
+    uint32_t code_size;
+    uint32_t initialized_data_size;
+    uint32_t uninitialized_data_size;
+    uint32_t entry_point_addr;
+    uint32_t code_base;
+    // All of these after, mostly Windows specific
+    uint64_t image_base;
+    uint32_t section_alignment;
+    uint32_t file_alignment;
+    uint16_t os_major_version;
+    uint16_t os_minor_version;
+    uint16_t image_major_version;
+    uint16_t image_minor_version;
+    uint16_t subsystem_major_version;
+    uint16_t subsystem_minor_version;
+    uint32_t win32_version;
+    uint32_t image_size;
+    uint32_t headers_size;
+    uint32_t checksum;
+    uint16_t subsystem;
+    uint16_t dll_characteristics;
+    uint64_t stack_reserve_size;
+    uint64_t stack_commit_size;
+    uint64_t heap_reserve_size;
+    uint64_t heap_commit_size;
+    uint32_t loader_flags;
+    uint32_t rva_amount_sizes;
+} __attribute__((packed));
+
+struct pe_section_header {
+    char name[8];
+    union {
+        uint32_t physical_addr;
+        uint32_t virtual_size;
+    };
+    uint32_t virtual_addr;
+    uint32_t aligned_size;
+    uint32_t data_ptr;
+    uint32_t rels_ptr;
+    uint32_t lines_ptr;
+    uint16_t relocations_amount;
+    uint16_t line_numbers;
+    uint32_t characteristics;
+} __attribute__((packed));
+
+int pe_bits(uint8_t *pe);
+
+int pe64_load(uint8_t *pe, uint64_t *entry_point, uint64_t *top, uint64_t *_slide, uint32_t alloc_type, bool kaslr);
+int pe64_load_section(uint8_t *pe, void *buffer, const char *name, size_t limit, uint64_t slide);
+
+int pe32_load(uint8_t *pe, uint32_t *entry_point, uint32_t *top, uint32_t alloc_type);
+int pe32_load_section(uint8_t *pe, void *buffer, const char *name, size_t limit);
+
+#endif


### PR DESCRIPTION
For the Windows shills! :D

Sadly, no KASLR and relocations support, since as far as I am aware PE doesn't support it natively and requires some hacks. There's also a problem with the `.stvl` section. PE seems to align sections to 32, and the stivale header is only 24 bytes big.