### PR TITLE
acpi: Fix wrong data type in tables header

### DIFF
--- a/stage23/lib/acpi.h
+++ b/stage23/lib/acpi.h
@@ -14,7 +14,7 @@ struct sdt {
     char     oem_id[6];
     char     oem_table_id[8];
     uint32_t oem_rev;
-    uint32_t creator_id;
+    char     creator_id[4];
     uint32_t creator_rev;
 } __attribute__((packed));
 


### PR DESCRIPTION
In ACPI specification version 6.4 page 21 "ACPI Data Tables and Table Definition Language" (21.2.1):
```
For example, the C definition of the common ACPI table header is as follows:

typedef struct acpi_table_header
{
    char Signature[4];
    UINT32 Length;
    UINT8 Revision;
    UINT8 Checksum;
    char OemId[6];
    char OemTableId[8];
    UINT32 OemRevision;
    char AslCompilerId[4];
    UINT32 AslCompilerRevision;
} ACPI_TABLE_HEADER;
```
"AslCompilerId" is defined as a 4 character array[¹](https://uefi.org/htmlspecs/ACPI_Spec_6_4_html/21_ACPI_Data_Tables_and_Table_Def_Language/ACPI_Data_Tables.html#overview-of-the-table-definition-language-tdl), while, the Limine ACPI implementation, defines "creator_id" (AKA "AslCompilerId") as a 4 byte (32-bit) integer.

This pull request solves the difference to comply with the specification.