### PR TITLE
multiboot2: initial support

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -87,7 +87,7 @@ Some keys take *URIs* as values; these are described in the next section.
 
 *Locally assignable (non protocol specific)* keys are:
 * `COMMENT` - An optional comment string that will be displayed by the bootloader on the menu when an entry is selected.
-* `PROTOCOL` - The boot protocol that will be used to boot the kernel. Valid protocols are: `linux`, `stivale`, `stivale2`, `chainload`, `multiboot` or `multiboot1`.
+* `PROTOCOL` - The boot protocol that will be used to boot the kernel. Valid protocols are: `linux`, `stivale`, `stivale2`, `chainload`, `multiboot` or `multiboot1` and `multiboot2`.
 * `CMDLINE` - The command line string to be passed to the kernel. Can be omitted.
 * `KERNEL_CMDLINE` - Alias of `CMDLINE`.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Like Limine and want to support it? Donate Bitcoin to
 * stivale and stivale2 (Limine's native boot protocols, see [their specifications](https://github.com/stivale/stivale) for details)
 * Linux
 * Multiboot 1
+* Multiboot 2
 * Chainloading
 
 ### Supported filesystems

--- a/stage23/entry.s3.c
+++ b/stage23/entry.s3.c
@@ -16,6 +16,7 @@
 #include <protos/linux.h>
 #include <protos/chainload.h>
 #include <protos/multiboot1.h>
+#include <protos/multiboot2.h>
 #include <menu.h>
 #include <pxe/pxe.h>
 #include <pxe/tftp.h>
@@ -168,6 +169,8 @@ void stage3_common(void) {
         chainload(config);
     } else if (!strcmp(proto, "multiboot1") || !strcmp(proto, "multiboot")) {
         multiboot1_load(config, cmdline);
+    } else if (!strcmp(proto, "multiboot2")) {
+        multiboot2_load(config, cmdline);
     }
 
     panic("Invalid protocol specified");

--- a/stage23/lib/elf.c
+++ b/stage23/lib/elf.c
@@ -249,30 +249,40 @@ int elf64_load_section(uint8_t *elf, void *buffer, const char *name, size_t limi
 
 /// SAFETY: The caller must ensure that the provided `elf` is a valid 64-bit
 /// ELF file.
-void elf64_section_hdr_info(uint8_t *elf, struct elf_section_hdr_info* info) {    
-    struct elf64_hdr hdr;
-    memcpy(&hdr, elf + (0), sizeof(struct elf32_hdr));
+void elf64_section_hdr_info(uint8_t *elf, struct elf_section_hdr_info** _info) {
+    struct elf_section_hdr_info* info = ext_mem_alloc(sizeof(struct elf_section_hdr_info));
 
-    info->section_hdr_size = hdr.sh_num * hdr.shdr_size;
+    struct elf64_hdr hdr;
+    memcpy(&hdr, elf + (0), sizeof(struct elf64_hdr));
+
+    info->num = hdr.sh_num;
     info->section_entry_size = hdr.shdr_size;
+    info->section_hdr_size = info->num * info->section_entry_size;
     info->str_section_idx = hdr.shstrndx;
     info->section_hdrs = ext_mem_alloc(info->section_hdr_size);
 
     memcpy(info->section_hdrs, elf + (hdr.shoff), info->section_hdr_size);
+
+    *_info = info;
 }
 
 /// SAFETY: The caller must ensure that the provided `elf` is a valid 64-bit
 /// ELF file.
-void elf32_section_hdr_info(uint8_t *elf, struct elf_section_hdr_info* info) {
+void elf32_section_hdr_info(uint8_t *elf, struct elf_section_hdr_info** _info) {
+    struct elf_section_hdr_info* info = ext_mem_alloc(sizeof(struct elf_section_hdr_info));
+
     struct elf32_hdr hdr;
     memcpy(&hdr, elf + (0), sizeof(struct elf32_hdr));
 
-    info->section_hdr_size = hdr.sh_num * hdr.shdr_size;
+    info->num = hdr.sh_num;
     info->section_entry_size = hdr.shdr_size;
+    info->section_hdr_size = info->num * info->section_entry_size;
     info->str_section_idx = hdr.shstrndx;
     info->section_hdrs = ext_mem_alloc(info->section_hdr_size);
 
     memcpy(info->section_hdrs, elf + (hdr.shoff), info->section_hdr_size);
+
+    *_info = info;
 }
 
 int elf32_load_section(uint8_t *elf, void *buffer, const char *name, size_t limit) {

--- a/stage23/lib/elf.c
+++ b/stage23/lib/elf.c
@@ -249,7 +249,7 @@ int elf64_load_section(uint8_t *elf, void *buffer, const char *name, size_t limi
 
 /// SAFETY: The caller must ensure that the provided `elf` is a valid 64-bit
 /// ELF file.
-void elf64_section_hdr_info(uint8_t *elf, struct elf_section_hdr_info** _info) {
+struct elf_section_hdr_info* elf64_section_hdr_info(uint8_t *elf) {
     struct elf_section_hdr_info* info = ext_mem_alloc(sizeof(struct elf_section_hdr_info));
 
     struct elf64_hdr hdr;
@@ -263,12 +263,12 @@ void elf64_section_hdr_info(uint8_t *elf, struct elf_section_hdr_info** _info) {
 
     memcpy(info->section_hdrs, elf + (hdr.shoff), info->section_hdr_size);
 
-    *_info = info;
+    return info;
 }
 
-/// SAFETY: The caller must ensure that the provided `elf` is a valid 64-bit
+/// SAFETY: The caller must ensure that the provided `elf` is a valid 32-bit
 /// ELF file.
-void elf32_section_hdr_info(uint8_t *elf, struct elf_section_hdr_info** _info) {
+struct elf_section_hdr_info* elf32_section_hdr_info(uint8_t *elf) {
     struct elf_section_hdr_info* info = ext_mem_alloc(sizeof(struct elf_section_hdr_info));
 
     struct elf32_hdr hdr;
@@ -282,7 +282,7 @@ void elf32_section_hdr_info(uint8_t *elf, struct elf_section_hdr_info** _info) {
 
     memcpy(info->section_hdrs, elf + (hdr.shoff), info->section_hdr_size);
 
-    *_info = info;
+    return info;
 }
 
 int elf32_load_section(uint8_t *elf, void *buffer, const char *name, size_t limit) {

--- a/stage23/lib/elf.c
+++ b/stage23/lib/elf.c
@@ -247,6 +247,34 @@ int elf64_load_section(uint8_t *elf, void *buffer, const char *name, size_t limi
     return 2;
 }
 
+/// SAFETY: The caller must ensure that the provided `elf` is a valid 64-bit
+/// ELF file.
+void elf64_section_hdr_info(uint8_t *elf, struct elf_section_hdr_info* info) {    
+    struct elf64_hdr hdr;
+    memcpy(&hdr, elf + (0), sizeof(struct elf32_hdr));
+
+    info->section_hdr_size = hdr.sh_num * hdr.shdr_size;
+    info->section_entry_size = hdr.shdr_size;
+    info->str_section_idx = hdr.shstrndx;
+    info->section_hdrs = ext_mem_alloc(info->section_hdr_size);
+
+    memcpy(info->section_hdrs, elf + (hdr.shoff), info->section_hdr_size);
+}
+
+/// SAFETY: The caller must ensure that the provided `elf` is a valid 64-bit
+/// ELF file.
+void elf32_section_hdr_info(uint8_t *elf, struct elf_section_hdr_info* info) {
+    struct elf32_hdr hdr;
+    memcpy(&hdr, elf + (0), sizeof(struct elf32_hdr));
+
+    info->section_hdr_size = hdr.sh_num * hdr.shdr_size;
+    info->section_entry_size = hdr.shdr_size;
+    info->str_section_idx = hdr.shstrndx;
+    info->section_hdrs = ext_mem_alloc(info->section_hdr_size);
+
+    memcpy(info->section_hdrs, elf + (hdr.shoff), info->section_hdr_size);
+}
+
 int elf32_load_section(uint8_t *elf, void *buffer, const char *name, size_t limit) {
     struct elf32_hdr hdr;
     memcpy(&hdr, elf + (0), sizeof(struct elf32_hdr));

--- a/stage23/lib/elf.h
+++ b/stage23/lib/elf.h
@@ -29,10 +29,10 @@ int elf_bits(uint8_t *elf);
 
 int elf64_load(uint8_t *elf, uint64_t *entry_point, uint64_t *top, uint64_t *_slide, uint32_t alloc_type, bool kaslr, bool use_paddr, struct elf_range **ranges, uint64_t *ranges_count);
 int elf64_load_section(uint8_t *elf, void *buffer, const char *name, size_t limit, uint64_t slide);
-void elf64_section_hdr_info(uint8_t *elf, struct elf_section_hdr_info** info);
+struct elf_section_hdr_info* elf64_section_hdr_info(uint8_t *elf);
 
 int elf32_load(uint8_t *elf, uint32_t *entry_point, uint32_t *top, uint32_t alloc_type);
 int elf32_load_section(uint8_t *elf, void *buffer, const char *name, size_t limit);
-void elf32_section_hdr_info(uint8_t *elf, struct elf_section_hdr_info** info);
+struct elf_section_hdr_info* elf32_section_hdr_info(uint8_t *elf);
 
 #endif

--- a/stage23/lib/elf.h
+++ b/stage23/lib/elf.h
@@ -17,12 +17,21 @@ struct elf_range {
     uint64_t permissions;
 };
 
+struct elf_section_hdr_info {
+    uint32_t section_hdr_size;
+    uint32_t section_entry_size;
+    uint32_t str_section_idx;
+    void* section_hdrs;
+};
+
 int elf_bits(uint8_t *elf);
 
 int elf64_load(uint8_t *elf, uint64_t *entry_point, uint64_t *top, uint64_t *_slide, uint32_t alloc_type, bool kaslr, bool use_paddr, struct elf_range **ranges, uint64_t *ranges_count);
 int elf64_load_section(uint8_t *elf, void *buffer, const char *name, size_t limit, uint64_t slide);
+void elf64_section_hdr_info(uint8_t *elf, struct elf_section_hdr_info* info);
 
 int elf32_load(uint8_t *elf, uint32_t *entry_point, uint32_t *top, uint32_t alloc_type);
 int elf32_load_section(uint8_t *elf, void *buffer, const char *name, size_t limit);
+void elf32_section_hdr_info(uint8_t *elf, struct elf_section_hdr_info* info);
 
 #endif

--- a/stage23/lib/elf.h
+++ b/stage23/lib/elf.h
@@ -21,6 +21,7 @@ struct elf_section_hdr_info {
     uint32_t section_hdr_size;
     uint32_t section_entry_size;
     uint32_t str_section_idx;
+    uint32_t num;
     void* section_hdrs;
 };
 
@@ -28,10 +29,10 @@ int elf_bits(uint8_t *elf);
 
 int elf64_load(uint8_t *elf, uint64_t *entry_point, uint64_t *top, uint64_t *_slide, uint32_t alloc_type, bool kaslr, bool use_paddr, struct elf_range **ranges, uint64_t *ranges_count);
 int elf64_load_section(uint8_t *elf, void *buffer, const char *name, size_t limit, uint64_t slide);
-void elf64_section_hdr_info(uint8_t *elf, struct elf_section_hdr_info* info);
+void elf64_section_hdr_info(uint8_t *elf, struct elf_section_hdr_info** info);
 
 int elf32_load(uint8_t *elf, uint32_t *entry_point, uint32_t *top, uint32_t alloc_type);
 int elf32_load_section(uint8_t *elf, void *buffer, const char *name, size_t limit);
-void elf32_section_hdr_info(uint8_t *elf, struct elf_section_hdr_info* info);
+void elf32_section_hdr_info(uint8_t *elf, struct elf_section_hdr_info** info);
 
 #endif

--- a/stage23/protos/multiboot2.32.c
+++ b/stage23/protos/multiboot2.32.c
@@ -1,0 +1,41 @@
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <mm/vmm.h>
+#if bios == 1
+#  include <sys/idt.h>
+#endif
+
+__attribute__((noreturn)) void multiboot2_spinup_32(
+                 uint32_t entry_point, uint32_t multiboot2_info) {
+#if bios == 1
+    struct idtr idtr;
+
+    idtr.limit = 0x3ff;
+    idtr.ptr = 0;
+
+    asm volatile (
+        "lidt %0"
+        :
+        : "m" (idtr)
+        : "memory"
+    );
+#endif
+
+    asm volatile (
+        "cld\n\t"
+
+        "pushl $0x18\n\t"
+        "pushl %%edi\n\t"
+
+        "movl $0x36D76289, %%eax\n\t"
+
+        "lret\n\t"
+        :
+        : "D" (entry_point),
+          "b" (multiboot2_info)
+        : "memory"
+    );
+
+    __builtin_unreachable();
+}

--- a/stage23/protos/multiboot2.c
+++ b/stage23/protos/multiboot2.c
@@ -106,23 +106,23 @@ void multiboot2_load(char *config, char* cmdline) {
     switch (bits) {
         case 32:
             if (elf32_load(kernel, &entry_point, &kernel_top, MEMMAP_KERNEL_AND_MODULES))
-                panic("multiboot1: ELF32 load failure");
+                panic("multiboot2: ELF32 load failure");
 
-            elf32_section_hdr_info(kernel, &section_hdr_info);
+            section_hdr_info = elf32_section_hdr_info(kernel);
             break;
         case 64: {
             uint64_t e, t;
             if (elf64_load(kernel, &e, &t, NULL, MEMMAP_KERNEL_AND_MODULES, false, true, NULL, NULL))
-                panic("multiboot1: ELF64 load failure");
+                panic("multiboot2: ELF64 load failure");
             
             entry_point = e;
             kernel_top = t;
 
-            elf64_section_hdr_info(kernel, &section_hdr_info);
+            section_hdr_info = elf64_section_hdr_info(kernel);
             break;
         }
         default:
-            panic("multiboot1: invalid ELF file bitness");
+            panic("multiboot2: invalid ELF file bitness");
     }
 
     print("multiboot2: found kernel entry point at: %x\n", entry_point);

--- a/stage23/protos/multiboot2.c
+++ b/stage23/protos/multiboot2.c
@@ -1,0 +1,223 @@
+#include <protos/multiboot2.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <lib/libc.h>
+#include <lib/elf.h>
+#include <lib/blib.h>
+#include <lib/config.h>
+#include <lib/print.h>
+#include <lib/uri.h>
+#include <lib/fb.h>
+#include <lib/term.h>
+#include <sys/pic.h>
+#include <sys/cpu.h>
+#include <fs/file.h>
+#include <mm/vmm.h>
+#include <mm/pmm.h>
+
+static uint8_t* multiboot2_info_buffer = NULL;
+static uint32_t multiboot2_info_size = 0;
+
+static struct multiboot_header* load_multiboot2_header(uint8_t* kernel) {
+    struct multiboot_header* ptr = {0};
+    struct multiboot_header header;
+
+    size_t header_offset = 0;
+
+    for (header_offset = 0; header_offset < MULTIBOOT_SEARCH; header_offset += MULTIBOOT_HEADER_ALIGN) {
+        uint32_t v;
+        memcpy(&v, kernel + header_offset, 4);
+
+        if (v == MULTIBOOT2_HEADER_MAGIC) {
+            memcpy(&header, kernel + header_offset, sizeof(header));
+
+            ptr = ext_mem_alloc(header.header_length);
+            memcpy(ptr, kernel + header_offset, header.header_length);
+
+            break;
+        }
+    }
+
+    if (ptr->magic != MULTIBOOT2_HEADER_MAGIC) {
+        panic("multiboot2: could not find header");
+    } else if (ptr->magic + ptr->architecture + ptr->checksum + ptr->header_length) {
+        panic("mutliboot2: header checksum is invalid");
+    }
+
+    return ptr;
+}
+
+static void* push_boot_param(void* data, uint32_t size) {
+    // Align up the allocation size to 8-bytes
+    uint32_t alloc_size = ALIGN_UP(size, MULTIBOOT_TAG_ALIGN); 
+
+    // Allocate the multiboot2 info buffer.
+    if (multiboot2_info_buffer == NULL) {
+        multiboot2_info_buffer = ext_mem_alloc(alloc_size);
+    } else {
+        uint8_t* old = multiboot2_info_buffer;
+        multiboot2_info_buffer = ext_mem_alloc(alloc_size + multiboot2_info_size);
+        memcpy(multiboot2_info_buffer, old, multiboot2_info_size);
+
+        // TODO: Free the old allocated buffer. Currently cannot do that since
+        // we do not have ext_mem_free and unmap_page yet.
+    }
+
+    // Copy the data to the buffer.
+    if (data != NULL) {
+        memcpy(multiboot2_info_buffer + multiboot2_info_size, data, size);
+    }
+
+    // Save the base we allocated from.
+    uint8_t* base = multiboot2_info_buffer + multiboot2_info_size;
+
+    // Update the size.
+    multiboot2_info_size += alloc_size;
+
+    // Return the base address of the multiboot2 tag we
+    // allocated.
+    return base;
+}
+
+void multiboot2_load(char *config, char* cmdline) {
+    struct file_handle *kernel_file = ext_mem_alloc(sizeof(*kernel_file));
+
+    char *kernel_path = config_get_value(config, 0, "KERNEL_PATH");
+    if (kernel_path == NULL)
+        panic("multiboot2: KERNEL_PATH not specified");
+
+    print("multiboot2: loading kernel `%s`...\n", kernel_path);
+
+    if (!uri_open(kernel_file, kernel_path))
+        panic("multiboot2: failed to open kernel with path `%s`. Is the path correct?", kernel_path);
+
+    uint8_t *kernel = freadall(kernel_file, MEMMAP_USABLE);
+    struct multiboot_header* header = load_multiboot2_header(kernel);
+
+    uint32_t entry_point;
+    uint32_t kernel_top;
+
+    int bits = elf_bits(kernel);
+    struct elf_section_hdr_info section_hdr_info;
+
+    switch (bits) {
+        case 32:
+            if (elf32_load(kernel, &entry_point, &kernel_top, MEMMAP_KERNEL_AND_MODULES))
+                panic("multiboot1: ELF32 load failure");
+
+            elf32_section_hdr_info(kernel, &section_hdr_info);
+            break;
+        case 64: {
+            uint64_t e, t;
+            if (elf64_load(kernel, &e, &t, NULL, MEMMAP_KERNEL_AND_MODULES, false, true, NULL, NULL))
+                panic("multiboot1: ELF64 load failure");
+            
+            entry_point = e;
+            kernel_top = t;
+
+            elf64_section_hdr_info(kernel, &section_hdr_info);
+            break;
+        }
+        default:
+            panic("multiboot1: invalid ELF file bitness");
+    }
+
+    print("multiboot2: found kernel entry point at: %X\n", entry_point);
+    
+    // Iterate through the entries...
+    for (struct multiboot_header_tag* tag = (struct multiboot_header_tag*)(header + 1);
+         tag < (struct multiboot_header_tag*)((uintptr_t)header + header->header_length) && tag->type != MULTIBOOT_HEADER_TAG_END;
+         tag = (struct multiboot_header_tag*)((uintptr_t)tag + ALIGN_UP(tag->size, MULTIBOOT_TAG_ALIGN))) {
+  
+        switch (tag->type) {
+            default: panic("multiboot2: unknown tag type");
+        }
+    }
+
+    uint32_t start_size = sizeof(struct multiboot2_start_tag*);
+    struct multiboot2_start_tag* mbi_start = (struct multiboot2_start_tag*)push_boot_param(NULL, start_size);
+
+    //////////////////////////////////////////////
+    // Create command line tag
+    //////////////////////////////////////////////
+    {
+        uint32_t size = strlen(cmdline) + 1 + offsetof(struct multiboot_tag_string, string);
+        struct multiboot_tag_string* tag = (struct multiboot_tag_string*)push_boot_param(NULL, size);
+    
+        tag->type = MULTIBOOT_TAG_TYPE_CMDLINE;
+        tag->size = size;
+
+        strcpy(tag->string, cmdline);
+    }
+
+    //////////////////////////////////////////////
+    // Create bootloader name tag
+    //////////////////////////////////////////////
+    {
+        char* brand = "Limine";
+        uint32_t size = sizeof(brand) + offsetof(struct multiboot_tag_string, string);
+        struct multiboot_tag_string* tag = (struct multiboot_tag_string*)push_boot_param(NULL, size);
+
+        tag->type = MULTIBOOT_TAG_TYPE_BOOT_LOADER_NAME;
+        tag->size = size;
+
+        strcpy(tag->string, brand);
+    }
+
+    //////////////////////////////////////////////
+    // Create framebuffer tag
+    //////////////////////////////////////////////
+    {
+    }
+
+    //////////////////////////////////////////////
+    // Create ELF info tag
+    //////////////////////////////////////////////
+    {
+        // ADD ME
+    }
+
+#if uefi == 1
+    efi_exit_boot_services();
+#endif
+
+    //////////////////////////////////////////////
+    // Create bootloader memory map tag
+    //////////////////////////////////////////////
+    {
+        size_t mb_mmap_count;
+        struct e820_entry_t *raw_memmap = get_raw_memmap(&mb_mmap_count);
+
+        // 1. Create the normal memory map tag.
+        uint32_t mmap_size = sizeof(struct multiboot_tag_mmap) + sizeof(struct multiboot_mmap_entry) * mb_mmap_count;
+        struct multiboot_tag_mmap* mmap_tag = (struct multiboot_tag_mmap*)push_boot_param(NULL, mmap_size);
+        
+        mmap_tag->type = MULTIBOOT_TAG_TYPE_MMAP;
+        mmap_tag->entry_size = sizeof(struct multiboot_mmap_entry);
+        mmap_tag->entry_version = 0;
+        mmap_tag->size = mmap_size;
+
+        for (size_t i = 0; i < mb_mmap_count; i++) {
+            struct multiboot_mmap_entry* entry = &mmap_tag->entries[i];
+            entry->addr = raw_memmap[i].base;
+            entry->len  = raw_memmap[i].length;
+            entry->type = raw_memmap[i].type;
+            entry->zero = 0;
+        }
+    }
+
+    //////////////////////////////////////////////
+    // Create end tag
+    //////////////////////////////////////////////
+    {
+        struct multiboot_tag* end_tag = push_boot_param(NULL, sizeof(struct multiboot_tag));
+        end_tag->type = MULTIBOOT_TAG_TYPE_END;
+        end_tag->size = sizeof(struct multiboot_tag);
+    }
+
+    mbi_start->size = multiboot2_info_size;
+    mbi_start->reserved = 0x00;
+
+    common_spinup(multiboot2_spinup_32, 2,
+                    entry_point, (uint32_t)(uintptr_t)multiboot2_info_buffer);
+}

--- a/stage23/protos/multiboot2.c
+++ b/stage23/protos/multiboot2.c
@@ -98,7 +98,7 @@ void multiboot2_load(char *config, char* cmdline) {
     uint32_t kernel_top;
 
     int bits = elf_bits(kernel);
-    struct elf_section_hdr_info section_hdr_info;
+    struct elf_section_hdr_info* section_hdr_info;
 
     switch (bits) {
         case 32:
@@ -122,7 +122,7 @@ void multiboot2_load(char *config, char* cmdline) {
             panic("multiboot1: invalid ELF file bitness");
     }
 
-    print("multiboot2: found kernel entry point at: %X\n", entry_point);
+    print("multiboot2: found kernel entry point at: %x\n", entry_point);
     
     // Iterate through the entries...
     for (struct multiboot_header_tag* tag = (struct multiboot_header_tag*)(header + 1);
@@ -174,7 +174,17 @@ void multiboot2_load(char *config, char* cmdline) {
     // Create ELF info tag
     //////////////////////////////////////////////
     {
-        // ADD ME
+        uint32_t size = sizeof(struct multiboot_tag_elf_sections) + section_hdr_info->section_hdr_size;
+        struct multiboot_tag_elf_sections* tag = (struct multiboot_tag_elf_sections*)push_boot_param(NULL, size);
+
+        tag->type = MULTIBOOT_TAG_TYPE_ELF_SECTIONS;
+        tag->size = size;
+
+        tag->num = section_hdr_info->num;
+        tag->entsize = section_hdr_info->section_entry_size;
+        tag->shndx = section_hdr_info->str_section_idx;
+
+        memcpy(tag->sections, section_hdr_info->section_hdrs, section_hdr_info->section_hdr_size);
     }
 
 #if uefi == 1

--- a/stage23/protos/multiboot2.h
+++ b/stage23/protos/multiboot2.h
@@ -1,3 +1,24 @@
+/*   multiboot2.h - Multiboot 2 header file. Copied from the multiboot2 specs /
+/   Copyright (C) 1999,2003,2007,2008,2009,2010  Free Software Foundation, Inc.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to
+ *  deal in the Software without restriction, including without limitation the
+ *  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ *  sell copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL ANY
+ *  DEVELOPER OR DISTRIBUTOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ *  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+ *  IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 #ifndef __PROTOS__MULTIBOOT2_H__
 #define __PROTOS__MULTIBOOT2_H__
 

--- a/stage23/protos/multiboot2.h
+++ b/stage23/protos/multiboot2.h
@@ -1,0 +1,399 @@
+#ifndef __PROTOS__MULTIBOOT2_H__
+#define __PROTOS__MULTIBOOT2_H__
+
+#include <stdint.h>
+
+void multiboot2_load(char *config, char* cmdline);
+
+/*  How many bytes from the start of the file we search for the header. */
+#define MULTIBOOT_SEARCH                        32768
+#define MULTIBOOT_HEADER_ALIGN                  8
+
+/*  The magic field should contain this. */
+#define MULTIBOOT2_HEADER_MAGIC                 0xe85250d6
+
+/*  This should be in %eax. */
+#define MULTIBOOT2_BOOTLOADER_MAGIC             0x36d76289
+
+/*  Alignment of multiboot modules. */
+#define MULTIBOOT_MOD_ALIGN                     0x00001000
+
+/*  Alignment of the multiboot info structure. */
+#define MULTIBOOT_INFO_ALIGN                    0x00000008
+
+/*  Flags set in the ’flags’ member of the multiboot header. */
+
+#define MULTIBOOT_TAG_ALIGN                  8
+#define MULTIBOOT_TAG_TYPE_END               0
+#define MULTIBOOT_TAG_TYPE_CMDLINE           1
+#define MULTIBOOT_TAG_TYPE_BOOT_LOADER_NAME  2
+#define MULTIBOOT_TAG_TYPE_MODULE            3
+#define MULTIBOOT_TAG_TYPE_BASIC_MEMINFO     4
+#define MULTIBOOT_TAG_TYPE_BOOTDEV           5
+#define MULTIBOOT_TAG_TYPE_MMAP              6
+#define MULTIBOOT_TAG_TYPE_VBE               7
+#define MULTIBOOT_TAG_TYPE_FRAMEBUFFER       8
+#define MULTIBOOT_TAG_TYPE_ELF_SECTIONS      9
+#define MULTIBOOT_TAG_TYPE_APM               10
+#define MULTIBOOT_TAG_TYPE_EFI32             11
+#define MULTIBOOT_TAG_TYPE_EFI64             12
+#define MULTIBOOT_TAG_TYPE_SMBIOS            13
+#define MULTIBOOT_TAG_TYPE_ACPI_OLD          14
+#define MULTIBOOT_TAG_TYPE_ACPI_NEW          15
+#define MULTIBOOT_TAG_TYPE_NETWORK           16
+#define MULTIBOOT_TAG_TYPE_EFI_MMAP          17
+#define MULTIBOOT_TAG_TYPE_EFI_BS            18
+#define MULTIBOOT_TAG_TYPE_EFI32_IH          19
+#define MULTIBOOT_TAG_TYPE_EFI64_IH          20
+#define MULTIBOOT_TAG_TYPE_LOAD_BASE_ADDR    21
+
+#define MULTIBOOT_HEADER_TAG_END  0
+#define MULTIBOOT_HEADER_TAG_INFORMATION_REQUEST  1
+#define MULTIBOOT_HEADER_TAG_ADDRESS  2
+#define MULTIBOOT_HEADER_TAG_ENTRY_ADDRESS  3
+#define MULTIBOOT_HEADER_TAG_CONSOLE_FLAGS  4
+#define MULTIBOOT_HEADER_TAG_FRAMEBUFFER  5
+#define MULTIBOOT_HEADER_TAG_MODULE_ALIGN  6
+#define MULTIBOOT_HEADER_TAG_EFI_BS        7
+#define MULTIBOOT_HEADER_TAG_ENTRY_ADDRESS_EFI32  8
+#define MULTIBOOT_HEADER_TAG_ENTRY_ADDRESS_EFI64  9
+#define MULTIBOOT_HEADER_TAG_RELOCATABLE  10
+
+#define MULTIBOOT_ARCHITECTURE_I386  0
+#define MULTIBOOT_ARCHITECTURE_MIPS32  4
+#define MULTIBOOT_HEADER_TAG_OPTIONAL 1
+
+#define MULTIBOOT_LOAD_PREFERENCE_NONE 0
+#define MULTIBOOT_LOAD_PREFERENCE_LOW 1
+#define MULTIBOOT_LOAD_PREFERENCE_HIGH 2
+
+#define MULTIBOOT_CONSOLE_FLAGS_CONSOLE_REQUIRED 1
+#define MULTIBOOT_CONSOLE_FLAGS_EGA_TEXT_SUPPORTED 2
+
+struct multiboot_header
+{
+    /*  Must be MULTIBOOT_MAGIC - see above. */
+    uint32_t magic;
+
+    /*  ISA */
+    uint32_t architecture;
+
+    /*  Total header length. */
+    uint32_t header_length;
+
+    /*  The above fields plus this one must equal 0 mod 2^32. */
+    uint32_t checksum;
+};
+
+struct multiboot_header_tag
+{
+    uint16_t type;
+    uint16_t flags;
+    uint32_t size;
+};
+
+struct multiboot_header_tag_information_request
+{
+    uint16_t type;
+    uint16_t flags;
+    uint32_t size;
+    uint32_t requests[0];
+};
+
+struct multiboot2_start_tag {
+    uint32_t size;
+    uint32_t reserved;
+};
+
+struct multiboot_header_tag_address
+{
+    uint16_t type;
+    uint16_t flags;
+    uint32_t size;
+    uint32_t header_addr;
+    uint32_t load_addr;
+    uint32_t load_end_addr;
+    uint32_t bss_end_addr;
+};
+
+struct multiboot_header_tag_entry_address
+{
+    uint16_t type;
+    uint16_t flags;
+    uint32_t size;
+    uint32_t entry_addr;
+};
+
+struct multiboot_header_tag_console_flags
+{
+    uint16_t type;
+    uint16_t flags;
+    uint32_t size;
+    uint32_t console_flags;
+};
+
+struct multiboot_header_tag_framebuffer
+{
+    uint16_t type;
+    uint16_t flags;
+    uint32_t size;
+    uint32_t width;
+    uint32_t height;
+    uint32_t depth;
+};
+
+struct multiboot_header_tag_module_align
+{
+    uint16_t type;
+    uint16_t flags;
+    uint32_t size;
+};
+
+struct multiboot_header_tag_relocatable
+{
+    uint16_t type;
+    uint16_t flags;
+    uint32_t size;
+    uint32_t min_addr;
+    uint32_t max_addr;
+    uint32_t align;
+    uint32_t preference;
+};
+
+struct multiboot_color
+{
+    uint8_t red;
+    uint8_t green;
+    uint8_t blue;
+};
+
+struct multiboot_mmap_entry
+{
+    uint64_t addr;
+    uint64_t len;
+#define MULTIBOOT_MEMORY_AVAILABLE              1
+#define MULTIBOOT_MEMORY_RESERVED               2
+#define MULTIBOOT_MEMORY_ACPI_RECLAIMABLE       3
+#define MULTIBOOT_MEMORY_NVS                    4
+#define MULTIBOOT_MEMORY_BADRAM                 5
+    uint32_t type;
+    uint32_t zero;
+};
+typedef struct multiboot_mmap_entry multiboot_memory_map_t;
+
+struct multiboot_tag
+{
+    uint32_t type;
+    uint32_t size;
+};
+
+struct multiboot_tag_string
+{
+    uint32_t type;
+    uint32_t size;
+    char string[0];
+};
+
+struct multiboot_tag_module
+{
+    uint32_t type;
+    uint32_t size;
+    uint32_t mod_start;
+    uint32_t mod_end;
+    char cmdline[0];
+};
+
+struct multiboot_tag_basic_meminfo
+{
+    uint32_t type;
+    uint32_t size;
+    uint32_t mem_lower;
+    uint32_t mem_upper;
+};
+
+struct multiboot_tag_bootdev
+{
+    uint32_t type;
+    uint32_t size;
+    uint32_t biosdev;
+    uint32_t slice;
+    uint32_t part;
+};
+
+struct multiboot_tag_mmap
+{
+    uint32_t type;
+    uint32_t size;
+    uint32_t entry_size;
+    uint32_t entry_version;
+    struct multiboot_mmap_entry entries[0];
+};
+
+struct multiboot_vbe_info_block
+{
+    uint8_t external_specification[512];
+};
+
+struct multiboot_vbe_mode_info_block
+{
+    uint8_t external_specification[256];
+};
+
+struct multiboot_tag_vbe
+{
+    uint32_t type;
+    uint32_t size;
+
+    uint16_t vbe_mode;
+    uint16_t vbe_interface_seg;
+    uint16_t vbe_interface_off;
+    uint16_t vbe_interface_len;
+
+    struct multiboot_vbe_info_block vbe_control_info;
+    struct multiboot_vbe_mode_info_block vbe_mode_info;
+};
+
+struct multiboot_tag_framebuffer_common
+{
+    uint32_t type;
+    uint32_t size;
+
+    uint64_t framebuffer_addr;
+    uint32_t framebuffer_pitch;
+    uint32_t framebuffer_width;
+    uint32_t framebuffer_height;
+    uint8_t framebuffer_bpp;
+#define MULTIBOOT_FRAMEBUFFER_TYPE_INDEXED 0
+#define MULTIBOOT_FRAMEBUFFER_TYPE_RGB     1
+#define MULTIBOOT_FRAMEBUFFER_TYPE_EGA_TEXT     2
+    uint8_t framebuffer_type;
+    uint16_t reserved;
+};
+
+struct multiboot_tag_framebuffer
+{
+    struct multiboot_tag_framebuffer_common common;
+
+    union
+    {
+        struct
+        {
+            uint16_t framebuffer_palette_num_colors;
+            struct multiboot_color framebuffer_palette[0];
+        };
+        struct
+        {
+            uint8_t framebuffer_red_field_position;
+            uint8_t framebuffer_red_mask_size;
+            uint8_t framebuffer_green_field_position;
+            uint8_t framebuffer_green_mask_size;
+            uint8_t framebuffer_blue_field_position;
+            uint8_t framebuffer_blue_mask_size;
+        };
+    };
+};
+
+struct multiboot_tag_elf_sections
+{
+    uint32_t type;
+    uint32_t size;
+    uint32_t num;
+    uint32_t entsize;
+    uint32_t shndx;
+    char sections[0];
+};
+
+struct multiboot_tag_apm
+{
+    uint32_t type;
+    uint32_t size;
+    uint16_t version;
+    uint16_t cseg;
+    uint32_t offset;
+    uint16_t cseg_16;
+    uint16_t dseg;
+    uint16_t flags;
+    uint16_t cseg_len;
+    uint16_t cseg_16_len;
+    uint16_t dseg_len;
+};
+
+struct multiboot_tag_efi32
+{
+    uint32_t type;
+    uint32_t size;
+    uint32_t pointer;
+};
+
+struct multiboot_tag_efi64
+{
+    uint32_t type;
+    uint32_t size;
+    uint64_t pointer;
+};
+
+struct multiboot_tag_smbios
+{
+    uint32_t type;
+    uint32_t size;
+    uint8_t major;
+    uint8_t minor;
+    uint8_t reserved[6];
+    uint8_t tables[0];
+};
+
+struct multiboot_tag_old_acpi
+{
+    uint32_t type;
+    uint32_t size;
+    uint8_t rsdp[0];
+};
+
+struct multiboot_tag_new_acpi
+{
+    uint32_t type;
+    uint32_t size;
+    uint8_t rsdp[0];
+};
+
+struct multiboot_tag_network
+{
+    uint32_t type;
+    uint32_t size;
+    uint8_t dhcpack[0];
+};
+
+struct multiboot_tag_efi_mmap
+{
+    uint32_t type;
+    uint32_t size;
+    uint32_t descr_size;
+    uint32_t descr_vers;
+    uint8_t efi_mmap[0];
+};
+
+struct multiboot_tag_efi32_ih
+{
+    uint32_t type;
+    uint32_t size;
+    uint32_t pointer;
+};
+
+struct multiboot_tag_efi64_ih
+{
+    uint32_t type;
+    uint32_t size;
+    uint64_t pointer;
+};
+
+struct multiboot_tag_load_base_addr
+{
+    uint32_t type;
+    uint32_t size;
+    uint32_t load_base_addr;
+};
+
+__attribute__((noreturn)) void multiboot2_spinup_32(
+                 uint32_t entry_point, uint32_t multiboot1_info);
+
+#endif


### PR DESCRIPTION
## Overview

This pull request adds support for the multiboot2 protocol in Limine. This can be useful since most of the people who switch to limine usually use Grub before and switching to limine then could be a huge pain. Being able to just use multiboot2 in limine would make this easier for people to switch from Grub. 

## Tests
I have tested this on a simple multiboot2 kernel (made in rust :D). I have currently marked this pull request as draft since some of the multiboot2 tags are yet to be implemented + some improvements in general about the codebase.

Signed-off-by: Andy-Python-Programmer <andypythonappdeveloper@gmail.com>