### PR TITLE
Override default higher-half offset address

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -84,6 +84,7 @@ Some keys take *URIs* as values; these are described in the next section.
 * `VERBOSE` - If set to `yes`, print additional information during boot. Defaults to not verbose.
 * `RANDOMISE_MEMORY` - If set to `yes`, randomise the contents of RAM at bootup in order to find bugs related to non zeroed memory or for security reasons. This option will slow down boot time significantly.
 * `RANDOMIZE_MEMORY` - Alias of `RANDOMISE_MEMORY`.
+* `HIGHER_HALF_OFFSET` - Can be used to override the default higher half load address. Defaults to `0xffffffff80000000`.
 
 *Locally assignable (non protocol specific)* keys are:
 * `COMMENT` - An optional comment string that will be displayed by the bootloader on the menu when an entry is selected.

--- a/stage23/lib/blib.c
+++ b/stage23/lib/blib.c
@@ -47,6 +47,21 @@ bool parse_resolution(size_t *width, size_t *height, size_t *bpp, const char *bu
     return true;
 }
 
+bool parse_address(uint64_t* addr, const char* addr_str)
+{
+  int base = 10;
+  if (strlen(addr_str) > 2 && addr_str[0] == '0' && addr_str[1] == 'x') {
+    addr_str += 2;
+    base = 16;
+  }
+
+  const char* end;
+  *addr = strtoui(addr_str, &end, base);
+  if (addr_str == end)
+    return false;
+  return true;
+}
+
 // This integer sqrt implementation has been adapted from:
 // https://stackoverflow.com/questions/1100090/looking-for-an-efficient-integer-square-root-algorithm-for-arm-thumb2
 uint64_t sqrt(uint64_t a_nInput) {

--- a/stage23/lib/blib.h
+++ b/stage23/lib/blib.h
@@ -34,6 +34,7 @@ extern bool stage3_loaded;
 
 extern bool verbose;
 
+bool parse_address(uint64_t* addr, const char* addr_str);
 bool parse_resolution(size_t *width, size_t *height, size_t *bpp, const char *buf);
 
 uint32_t get_crc32(void *_stream, size_t len);

--- a/stage23/lib/elf.c
+++ b/stage23/lib/elf.c
@@ -7,6 +7,7 @@
 #include <lib/rand.h>
 #include <mm/pmm.h>
 #include <fs/file.h>
+#include <lib/config.h>
 
 #define PT_LOAD     0x00000001
 #define PT_INTERP   0x00000003
@@ -465,7 +466,7 @@ final:
 
             if (load_addr & ((uint64_t)1 << 63)) {
                 higher_half = true;
-                load_addr -= FIXED_HIGHER_HALF_OFFSET_64;
+                load_addr -= elf64_get_higher_half_offset();
             }
         }
 
@@ -607,4 +608,14 @@ int elf32_load(uint8_t *elf, uint32_t *entry_point, uint32_t *top, uint32_t allo
     *entry_point = entry;
 
     return 0;
+}
+
+uint64_t elf64_get_higher_half_offset()
+{
+  const char* offset_str = config_get_value(NULL, 0, "HIGHER_HALF_OFFSET");
+
+  uint64_t addr;
+  if (offset_str == NULL || !parse_address(&addr, offset_str))
+    return DEFAULT_HIGHER_HALF_OFFSET_64;
+  return addr;
 }

--- a/stage23/lib/elf.h
+++ b/stage23/lib/elf.h
@@ -5,7 +5,7 @@
 #include <stdbool.h>
 #include <fs/file.h>
 
-#define FIXED_HIGHER_HALF_OFFSET_64 ((uint64_t)0xffffffff80000000)
+#define DEFAULT_HIGHER_HALF_OFFSET_64 ((uint64_t)0xffffffff80000000)
 
 #define ELF_PF_X 1
 #define ELF_PF_W 2
@@ -34,5 +34,7 @@ struct elf_section_hdr_info* elf64_section_hdr_info(uint8_t *elf);
 int elf32_load(uint8_t *elf, uint32_t *entry_point, uint32_t *top, uint32_t alloc_type);
 int elf32_load_section(uint8_t *elf, void *buffer, const char *name, size_t limit);
 struct elf_section_hdr_info* elf32_section_hdr_info(uint8_t *elf);
+
+uint64_t elf64_get_higher_half_offset();
 
 #endif

--- a/stage23/protos/stivale.c
+++ b/stage23/protos/stivale.c
@@ -332,7 +332,7 @@ pagemap_t stivale_build_pagemap(bool level5pg, bool unmap_null, struct elf_range
             uint64_t phys = virt;
 
             if (phys & ((uint64_t)1 << 63)) {
-                phys -= FIXED_HIGHER_HALF_OFFSET_64;
+                phys -= elf64_get_higher_half_offset();
             } else {
                 panic("stivale2: Protected memory ranges are only supported for higher half kernels");
             }

--- a/stage23/protos/stivale2.c
+++ b/stage23/protos/stivale2.c
@@ -34,7 +34,7 @@ struct stivale2_struct stivale2_struct = {0};
 
 inline static size_t get_phys_addr(uint64_t addr) {
     if (addr & ((uint64_t)1 << 63))
-        return addr - FIXED_HIGHER_HALF_OFFSET_64;
+        return addr - elf64_get_higher_half_offset();
     return addr;
 }
 
@@ -403,7 +403,7 @@ failed_to_load_header_section:
     char *textmode_str = config_get_value(config, 0, "TEXTMODE");
     bool textmode = textmode_str != NULL && strcmp(textmode_str, "yes") == 0;
 
-    int preference;
+    int preference = 0;
     if (avtag != NULL) {
         preference = textmode ? 1 : avtag->preference;
     }


### PR DESCRIPTION
Currently the default load offset address for higher-half kernels is hardcoded in `stage23/lib/elf.h`. This PR makes the hardcoded value a default and adds a configuration option to override it. 

I use it to let my own kernel load at an address near `0xffff800000000000`, but I thought maybe other people would like to configure this for themselves as well.