### PR TITLE
Issue with gnu-efi url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ toolchain:
 	MAKE="$(MAKE)" aux/make_toolchain.sh "`pwd`/toolchain" -j$(NCPUS)
 
 gnu-efi:
-	git clone https://git.code.sf.net/p/gnu-efi/code --branch=3.0.14 --depth=1 $@
+	git clone https://git.code.sf.net/p/gnu-efi/code --branch=3.0.14 --depth=1 gnu-efi $@
 	cp aux/elf/* gnu-efi/inc/
 
 ovmf-x64:


### PR DESCRIPTION
Original URL didnt work. Also, run export GIT_SSL_NO_VERIFY=1 as it seems there's something wrong on sourceforge's end.