### PR TITLE
stivale+stivale2: default to file path as the module string if NULL

### DIFF
--- a/stage23/protos/stivale.c
+++ b/stage23/protos/stivale.c
@@ -202,13 +202,24 @@ void stivale_load(char *config, char *cmdline) {
         struct stivale_module *m = ext_mem_alloc(sizeof(struct stivale_module));
 
         char *module_string = config_get_value(config, i, "MODULE_STRING");
+
+        // TODO: perhaps change the module string to to be a pointer.
+        //
+        // NOTE: By default, the module string is the file name.
         if (module_string == NULL) {
-            m->string[0] = '\0';
+            size_t str_len = strlen(module_path);
+
+            if (str_len > 127)
+                str_len = 127;
+
+            memcpy(m->string, module_path, str_len);
         } else {
             // TODO perhaps change this to be a pointer
             size_t str_len = strlen(module_string);
+            
             if (str_len > 127)
                 str_len = 127;
+            
             memcpy(m->string, module_string, str_len);
         }
 

--- a/stage23/protos/stivale2.c
+++ b/stage23/protos/stivale2.c
@@ -313,13 +313,23 @@ failed_to_load_header_section:
         struct stivale2_module *m = &tag->modules[i];
 
         char *module_string = config_get_value(config, i, "MODULE_STRING");
+
+        // TODO: perhaps change the module string to to be a pointer.
+        //
+        // NOTE: By default, the module string is the file name.
         if (module_string == NULL) {
-            m->string[0] = '\0';
-        } else {
-            // TODO perhaps change this to be a pointer
-            size_t str_len = strlen(module_string);
+            size_t str_len = strlen(module_path);
+
             if (str_len > 127)
                 str_len = 127;
+
+            memcpy(m->string, module_path, str_len);
+        } else {
+            size_t str_len = strlen(module_string);
+            
+            if (str_len > 127)
+                str_len = 127;
+            
             memcpy(m->string, module_string, str_len);
         }
 

--- a/test/limine.cfg
+++ b/test/limine.cfg
@@ -21,6 +21,8 @@ KERNEL_CMDLINE=Woah! Another example!
 MODULE_PATH=boot:///boot/bg.bmp
 MODULE_STRING=yooooo
 
+MODULE_PATH=boot:///boot/bg.bmp
+
 :EFI Chainloading
 
 COMMENT=Test EFI image chainloading.


### PR DESCRIPTION
This pull request adds (stivale+stivale2):

* If a module string is not specified for a module then it defaults to use the file path as the module string instead. Instead of just setting it to `NULL`. Since just specifying an empty string is not a good indication but specifying the path is actually more saner.

* An alternate solution would be to pass the file name instead of the file path but I picked to use the full file path since eh its less conflict able with similar file modules.

Signed-off-by: Andy-Python-Programmer <andypythonappdeveloper@gmail.com>