### PR TITLE
bootboot: add initrd support, and add a warning about the init stack

### DIFF
--- a/stage23/protos/bootboot.c
+++ b/stage23/protos/bootboot.c
@@ -186,7 +186,7 @@ void bootboot_load(char *config) {
 
     if (init_stack_size == ~0UL) {
         print("bootboot: warning: no init stack size entered, assuming 1024\n");
-        print("1024 is really small, specify more using ");
+        print("1024 is really small, specify more using initstack=size ini initrd;\n");
         init_stack_size = 1024;
     }
     printv("bootboot: mapping struct to %X\n", struct_vaddr);

--- a/stage23/protos/bootboot.c
+++ b/stage23/protos/bootboot.c
@@ -135,8 +135,6 @@ void bootboot_load(char *config) {
 
     /// Memory mappings ///
     pagemap_t pmap = new_pagemap(4);
-    BOOTBOOT* bootboot = (BOOTBOOT*)ext_mem_alloc_type_aligned(4096, MEMMAP_BOOTLOADER_RECLAIMABLE, 4096);
-    map_page(pmap, struct_vaddr, (uint64_t)(size_t)bootboot, VMM_FLAG_PRESENT | VMM_FLAG_WRITE, false);
 
     /// Load kernel ///
     uint64_t entry, top, slide, rangecount, physbase, virtbase = 0;
@@ -193,6 +191,11 @@ void bootboot_load(char *config) {
     printv("bootboot: mapping environemnt to %X\n", env_vaddr);
     printv("bootboot: mapping framebuffer to %X\n", fb_vaddr);
     printv("bootboot: the init stack is %X bytes\n", init_stack_size);;
+
+    /// Bootboot structure ///
+    BOOTBOOT* bootboot = (BOOTBOOT*)ext_mem_alloc_type_aligned(4096, MEMMAP_BOOTLOADER_RECLAIMABLE, 4096);
+    map_page(pmap, struct_vaddr, (uint64_t)(size_t)bootboot, VMM_FLAG_PRESENT | VMM_FLAG_WRITE, false);
+
 
     /// Environment ///
     {

--- a/stage23/protos/bootboot.c
+++ b/stage23/protos/bootboot.c
@@ -186,6 +186,7 @@ void bootboot_load(char *config) {
         print("bootboot: warning: no init stack size entered, assuming 1024\n");
         print("1024 is really small, specify more using initstack=size ini initrd;\n");
         init_stack_size = 1024;
+        delay(1000000);
     }
     printv("bootboot: mapping struct to %X\n", struct_vaddr);
     printv("bootboot: mapping environemnt to %X\n", env_vaddr);

--- a/stage23/protos/bootboot.c
+++ b/stage23/protos/bootboot.c
@@ -196,7 +196,6 @@ void bootboot_load(char *config) {
     BOOTBOOT* bootboot = (BOOTBOOT*)ext_mem_alloc_type_aligned(4096, MEMMAP_BOOTLOADER_RECLAIMABLE, 4096);
     map_page(pmap, struct_vaddr, (uint64_t)(size_t)bootboot, VMM_FLAG_PRESENT | VMM_FLAG_WRITE, false);
 
-
     /// Environment ///
     {
         map_page(pmap, env_vaddr, (uint64_t)(size_t)env, VMM_FLAG_PRESENT | VMM_FLAG_WRITE, false);

--- a/stage23/protos/bootboot/cpio.c
+++ b/stage23/protos/bootboot/cpio.c
@@ -1,0 +1,75 @@
+#include "lib/print.h"
+#include <protos/bootboot/initrd.h>
+#include <lib/libc.h>
+#include <stdint.h>
+
+#define HPODC_MAGIC "070707"
+
+/**
+ * cpio archive
+ */
+INITRD_HANDLER(cpio) {
+    /// Some macros///
+#define _offset(cnt) do { offset += (cnt); if (offset > file.size) return (file_t){ 0, NULL }; } while (false);
+#define _atoffset() (&file.data[offset])
+#define _must(n) do { if ((offset + (n)) > file.size) return (file_t){ 0, NULL }; } while (false);
+    uint64_t offset = 0;
+    if (file.size < 6) return (file_t){ 0, NULL };
+
+    /// Check magic ///
+    // this may be a bit unclear, but this checks if the file even **has** a cpio header
+    if (memcmp(file.data,"070701",6) && memcmp(file.data, "070702", 6) && memcmp(file.data, "070707", 6))
+        return (file_t){ 0, NULL };
+    
+    /// Some variables ///
+    uint64_t path_name_size = strlen(path);
+
+    /// hpodc archive ///
+    while (!memcmp(_atoffset(), HPODC_MAGIC, 6)) {
+        _must(22);
+        uint32_t name_size = oct2bin(_atoffset()+ 8 * 6 + 11, 6);
+        uint32_t file_size = oct2bin(_atoffset()+ 8 * 6 + 11 + 6, 11);
+        _must(9 * 6 + 2 * 11 + name_size);
+
+        uint8_t* target_path = _atoffset() + 9 * 6 + 2 * 11;
+
+        if (name_size > 2 && target_path[0] == '.' && target_path[1] == '/') {
+            target_path += 2;
+        }
+
+        if (!memcmp(target_path, path, path_name_size + 1)) {
+            return (file_t){
+                file_size,
+                _atoffset() + 9 * 6 + 2 * 11 + name_size,
+            };
+        }
+        _offset(76 + name_size + file_size);
+    }
+    offset = 0;
+    // newc and crc archive
+    while(!memcmp(_atoffset(), "07070", 5)){
+        uint32_t file_size = hex2bin(_atoffset() + 8 * 6 + 6, 8);
+        uint32_t name_size = hex2bin(_atoffset() + 8 * 11 + 6, 8);
+
+        uint8_t* target_path = _atoffset() + 110;
+
+        if (name_size > 2 && target_path[0] == '.' && target_path[1] == '/') {
+            target_path += 2;
+        }
+        
+        if (!memcmp(target_path, path, path_name_size + 1)) {
+            uint8_t buf[9];
+            memcpy(buf, _atoffset() + 8 * 11 + 6, 8);
+            buf[8] = 0;
+            return (file_t){
+                file_size,
+                (_atoffset() + ((110 + name_size + 3) / 4) * 4),
+            };
+        }
+        _offset(((110 + name_size + 3) / 4) * 4 + ((file_size + 3) / 4) * 4);
+    }
+    char buf[9];
+    memcpy(buf, _atoffset(), 8);
+    buf[8] = 0;
+    return (file_t){ 0, NULL };
+}

--- a/stage23/protos/bootboot/initrd.c
+++ b/stage23/protos/bootboot/initrd.c
@@ -11,7 +11,7 @@ INITRD_HANDLER(cpio);
 INITRD_HANDLER(auto) {
 #define DETECT_FAILED panic("bootboot: cannot read file `%s`: cannot detect initrd type (only ustar, cpio and jamesm is supported).", path)
     if (file.size < 4) DETECT_FAILED;
-    if (!memcmp(file.data, "ELF\x7f", 4)) {
+    if (!memcmp(file.data, "\x7f""ELF", 4)) {
         if (strcmp("sys/core", path) == 0) {
             printv("bootboot: using ELF as initrd to open sys/core\n");
             return file;

--- a/stage23/protos/bootboot/initrd.c
+++ b/stage23/protos/bootboot/initrd.c
@@ -1,0 +1,72 @@
+#include <protos/bootboot/initrd.h>
+#include <lib/print.h>
+#include <lib/libc.h>
+#include <lib/blib.h>
+
+
+INITRD_HANDLER(jamesm);
+INITRD_HANDLER(ustar);
+INITRD_HANDLER(cpio);
+
+INITRD_HANDLER(auto) {
+#define DETECT_FAILED panic("bootboot: cannot read file `%s`: cannot detect initrd type (only ustar, cpio and jamesm is supported).", path)
+    if (file.size < 4) DETECT_FAILED;
+    if (!memcmp(file.data, "ELF\x7f", 4)) {
+        if (strcmp("sys/core", path) == 0) {
+            printv("bootboot: using ELF as initrd to open sys/core\n");
+            return file;
+        }
+        return (file_t){0, NULL};
+    }
+    if (file.size < 5) DETECT_FAILED;
+    if (file.data[4] == 0xBF) {
+        file_t jamesm_attempt = initrd_open_jamesm(file, path);
+        if (jamesm_attempt.data) {
+            printv("bootboot: jamesm matched when reading file `%s`\n", path);
+            return jamesm_attempt;
+        }
+        panic("bootboot: cannot read file `%s`: no such file or directory", path);
+    }
+    if (!memcmp("07070", file.data, 5)) {
+        file_t cpio_attempt = initrd_open_cpio(file, path);
+        if (cpio_attempt.data) {
+            printv("bootboot: cpio matched when reading file `%s`\n", path);
+            return cpio_attempt;
+        }
+        panic("bootboot: cannot read file `%s`: no such file or directory", path);
+    }
+    if (file.size < 262) DETECT_FAILED;
+    if (!memcmp("ustar", file.data + 257, 5)) {
+        file_t ustar_attempt = initrd_open_ustar(file, path);
+        if (ustar_attempt.data) {
+            printv("bootboot: ustar matched when reading file `%s`\n", path);
+            return ustar_attempt;
+        }
+        panic("bootboot: cannot read file `%s`: no such file or directory", path);
+    }
+    DETECT_FAILED;
+}
+
+/// Utilities ///
+uint32_t oct2bin(uint8_t* str, uint32_t max) {
+    uint32_t value = 0;
+    while(max-- > 0) {
+        value <<= 3;
+        value += *str++ - '0';
+    }
+    return value;
+}
+uint32_t hex2bin(uint8_t* str, uint32_t size) {
+    uint32_t value = 0;
+    while(size-- > 0){
+        value <<= 4;
+        if (*str >= '0' && *str <= '9')
+            value += (uint32_t)((*str) - '0');
+        else if (*str >= 'A' && *str <= 'F')
+            value += (uint32_t)((*str) - 'A' + 10);
+        else if (*str >= 'a' && *str <= 'f')
+            value += (uint32_t)((*str) - 'a' + 10);
+        str++;
+    }
+    return value;
+}

--- a/stage23/protos/bootboot/initrd.h
+++ b/stage23/protos/bootboot/initrd.h
@@ -1,0 +1,19 @@
+#ifndef __PROTOS__BOOTBOOT_FS_H__
+#define __PROTOS__BOOTBOOT_FS_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef struct file {
+    uint64_t size;
+    uint8_t* data;
+} file_t;
+
+#define INITRD_HANDLER(name) file_t initrd_open_##name(file_t file, const char* path)
+
+INITRD_HANDLER(auto);
+
+uint32_t oct2bin(uint8_t* str, uint32_t max);
+uint32_t hex2bin(uint8_t* str, uint32_t size);
+
+#endif

--- a/stage23/protos/bootboot/jamesm.c
+++ b/stage23/protos/bootboot/jamesm.c
@@ -1,0 +1,32 @@
+#include <protos/bootboot/initrd.h>
+#include <lib/libc.h>
+#include <stdint.h>
+
+// This looks really sketchy, but that's what the official """spec""" says...
+typedef struct initrd_header {
+   unsigned char magic; // The magic number is there to check for consistency.
+   char name[64];
+   unsigned int offset; // Offset in the initrd the file starts.
+   unsigned int length; // Length of the file.
+} initrd_entry_t;
+
+INITRD_HANDLER(jamesm) {
+    if (file.size < 5) return (file_t){};
+
+    uint32_t file_count = *((uint32_t*)(file.data));
+    uint32_t path_len = strlen(path);
+
+    initrd_entry_t* data = (initrd_entry_t*)(file.data + 4);
+    if (data[0].magic != 0xBF) return (file_t){};
+
+    for(uint32_t i = 0;i < file_count;i++) {
+        if (data[i].magic != 0xBF) return (file_t){};
+        if(!memcmp(data[i].name, path, path_len + 1)){
+            return (file_t){
+                data[i].length,
+                file.data + data[i].offset
+            };
+        }
+    }
+    return (file_t){};
+}

--- a/stage23/protos/bootboot/ustar.c
+++ b/stage23/protos/bootboot/ustar.c
@@ -1,0 +1,27 @@
+#include <protos/bootboot/initrd.h>
+#include <lib/libc.h>
+#include <stdint.h>
+
+INITRD_HANDLER(ustar) {
+#define PTR (file.data + offset)
+    if (file.size < 262) return (file_t){};
+
+    if(memcmp(file.data + 257, "ustar", 5))
+        return (file_t){};
+    
+    uint32_t path_size = strlen(path);
+    uint32_t offset = 0;
+
+    while(!memcmp(PTR + 257,"ustar",5)){
+        uint32_t file_size = oct2bin(PTR + 0x7c,11);
+        if(!memcmp(PTR, path, path_size + 1)
+             || (PTR[0] == '.' && PTR[1] == '/' && !memcmp(PTR + 2, path, path_size + 1))) {
+            return (file_t){
+                file_size,
+                PTR+512,
+            };
+        }
+        offset += (((file_size + 511) / 512) + 1) * 512;
+    }
+    return (file_t){};
+}


### PR DESCRIPTION
This PR finishes bootboot support, for now at least, by adding support for the bootboot initrd things!

This means bootboot support is complete!

The initrd formats supported are:
 - cpio (oldc, newc and maybe crc)
 - ustar
 - raw kernel elf file that gets loaded directly

The KERNEL_PATH variable is treated as INITRD_PATH, except when INITRD_PATH is set too, when it overrides the kernel in the initrd.

Where does the kernel and initrd come from?
| KERNEL_PATH | INITRD_PATH | initrd        | kernel    |
|-------------|-------------|---------------|---------------|
| no          | no          | N/A           | N/A           |
| elf         | no          | kernel_path   | kernel_path   |
| elf         | any         | initrd_path   | kernel_path   |
| archive     | any         | N/A           | N/A           |
| no          | archive     | initrd_path   | initrd        |
| no          | elf         | initrd_path   | initrd_path   |

initrd_path: the initrd binary
initrd: the kernel fine inside of the initrd
kernel_path: the kernel binary
N/A: doesn't work