### PR TITLE
fix limine-install on BIOS disks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ install: all
 	install -d "$(DESTDIR)$(PREFIX)/share"
 	install -d "$(DESTDIR)$(PREFIX)/share/limine"
 	install -m 644 bin/limine.sys "$(DESTDIR)$(PREFIX)/share/limine/" || true
+	install -m 644 bin/limine-hdd.bin "$(DESTDIR)$(PREFIX)/share/limine/" || true
 	install -m 644 bin/limine-cd.bin "$(DESTDIR)$(PREFIX)/share/limine/" || true
 	install -m 644 bin/limine-eltorito-efi.bin "$(DESTDIR)$(PREFIX)/share/limine/" || true
 	install -m 644 bin/limine-pxe.bin "$(DESTDIR)$(PREFIX)/share/limine/" || true


### PR DESCRIPTION
Without `limine-hdd.bin` limine-install is unsuccessfull:
```
$ sudo limine-install /dev/sda
Physical block size of 512 bytes.
ERROR: Could not determine if the device has a valid partition table.
       Please ensure the device has a valid MBR or GPT.
       Alternatively, pass `--force-mbr` at the end of the command to
       override these checks. ONLY DO THIS AT YOUR OWN RISK, DATA LOSS
       MAY OCCUR!
$ sudo limine-install --force-mbr  /dev/sda
ERROR: No such file or directory
```