### PR TITLE
Made panic more robust for BIOS

### DIFF
--- a/stage23/drivers/vga_textmode.s2.c
+++ b/stage23/drivers/vga_textmode.s2.c
@@ -139,7 +139,7 @@ void init_vga_textmode(size_t *_rows, size_t *_cols, bool managed) {
         current_video_mode = -1;
     }
 
-    if (!pmm_allocation_allowed()) {
+    if (allocations_disallowed) {
         front_buffer = back_buffer = video_mem;
     }
 

--- a/stage23/drivers/vga_textmode.s2.c
+++ b/stage23/drivers/vga_textmode.s2.c
@@ -139,10 +139,6 @@ void init_vga_textmode(size_t *_rows, size_t *_cols, bool managed) {
         current_video_mode = -1;
     }
 
-    if (allocations_disallowed) {
-        front_buffer = back_buffer = video_mem;
-    }
-
     if (back_buffer == NULL) {
         back_buffer = ext_mem_alloc(VD_ROWS * VD_COLS);
     } else {

--- a/stage23/drivers/vga_textmode.s2.c
+++ b/stage23/drivers/vga_textmode.s2.c
@@ -139,6 +139,10 @@ void init_vga_textmode(size_t *_rows, size_t *_cols, bool managed) {
         current_video_mode = -1;
     }
 
+    if (!pmm_allocation_allowed()) {
+        front_buffer = back_buffer = video_mem;
+    }
+
     if (back_buffer == NULL) {
         back_buffer = ext_mem_alloc(VD_ROWS * VD_COLS);
     } else {

--- a/stage23/lib/panic.s2.c
+++ b/stage23/lib/panic.s2.c
@@ -12,6 +12,7 @@
 
 static const char* recursive_panic = 0;
 
+#if bios == 1
 void fallback_print (const char* string) {
     int i;
     struct rm_regs r = {0};
@@ -20,6 +21,7 @@ void fallback_print (const char* string) {
         rm_int(0x10,&r,&r);
     }
 }
+#endif
 
 __attribute__((noreturn)) void panic(const char *fmt, ...) {
 

--- a/stage23/lib/panic.s2.c
+++ b/stage23/lib/panic.s2.c
@@ -13,12 +13,12 @@
 static const char* recursive_panic = 0;
 
 #if bios == 1
-void fallback_print (const char* string) {
+void fallback_print(const char *string) {
     int i;
     struct rm_regs r = {0};
     for (i=0; string[i]; i++) {
-        r.eax = 0x0E00|string[i];
-        rm_int(0x10,&r,&r);
+        r.eax = 0x0e00 | string[i];
+        rm_int(0x10, &r, &r);
     }
 }
 #endif
@@ -34,8 +34,8 @@ __attribute__((noreturn)) void panic(const char *fmt, ...) {
     if (recursive_panic) {
 #if bios == 1
         struct rm_regs r = {0};
-        rm_int(0x11,&r,&r);
-        switch ((r.eax>>4)&3) {
+        rm_int(0x11, &r, &r);
+        switch ((r.eax >> 4) & 3) {
             case 0:
                 r.eax = 3;
                 break;
@@ -49,7 +49,7 @@ __attribute__((noreturn)) void panic(const char *fmt, ...) {
                 r.eax = 7;
                 break;
         }
-        rm_int(0x10,&r,&r);
+        rm_int(0x10, &r, &r);
         fallback_print("RECURSIVE PANIC: \r\n");
         fallback_print("Original panic: ");
         fallback_print(recursive_panic);

--- a/stage23/lib/panic.s2.c
+++ b/stage23/lib/panic.s2.c
@@ -10,12 +10,55 @@
 #include <lib/term.h>
 #include <mm/pmm.h>
 
+static const char* recursive_panic = 0;
+
+void fallback_print (const char* string) {
+    int i;
+    struct rm_regs r = {0};
+    for (i=0; string[i]; i++) {
+        r.eax = 0x0E00|string[i];
+        rm_int(0x10,&r,&r);
+    }
+}
+
 __attribute__((noreturn)) void panic(const char *fmt, ...) {
+
     va_list args;
 
     va_start(args, fmt);
 
     quiet = false;
+
+    if (recursive_panic) {
+#if bios == 1
+        struct rm_regs r = {0};
+        rm_int(0x11,&r,&r);
+        switch ((r.eax>>4)&3) {
+            case 0:
+                r.eax = 3;
+                break;
+            case 1:
+                r.eax = 1;
+                break;
+            case 2:
+                r.eax = 3;
+                break;
+            case 3:
+                r.eax = 7;
+                break;
+        }
+        rm_int(0x10,&r,&r);
+        fallback_print("RECURSIVE PANIC: \r\n");
+        fallback_print("Original panic: ");
+        fallback_print(recursive_panic);
+        fallback_print("\r\nSubsequent panic: ");
+        fallback_print(fmt);
+        fallback_print("\r\nPress CTRL+ALT+DEL to reboot.");
+        rm_hcf();
+#endif
+    }
+
+    recursive_panic = fmt;
 
     if (term_backend == NOT_READY) {
 #if bios == 1

--- a/stage23/lib/term.c
+++ b/stage23/lib/term.c
@@ -5,6 +5,7 @@
 #include <lib/image.h>
 #include <lib/blib.h>
 #include <lib/gterm.h>
+#include <mm/pmm.h>
 
 bool early_term = false;
 
@@ -20,7 +21,7 @@ void term_deinit(void) {
 void term_vbe(size_t width, size_t height) {
     term_notready();
 
-    if (quiet) {
+    if (quiet || allocations_disallowed) {
         return;
     }
 

--- a/stage23/lib/term.h
+++ b/stage23/lib/term.h
@@ -35,7 +35,8 @@ extern struct term_context {
 enum {
     NOT_READY,
     VBE,
-    TEXTMODE
+    TEXTMODE,
+    FALLBACK
 };
 
 extern int current_video_mode;

--- a/stage23/lib/term.s2.c
+++ b/stage23/lib/term.s2.c
@@ -7,6 +7,7 @@
 #include <lib/blib.h>
 #include <drivers/vga_textmode.h>
 #include <lib/print.h>
+#include <mm/pmm.h>
 
 // Tries to implement this standard for terminfo
 // https://man7.org/linux/man-pages/man4/console_codes.4.html
@@ -157,7 +158,7 @@ void term_reinit(void) {
 void term_textmode(void) {
     term_notready();
 
-    if (quiet) {
+    if (quiet || allocations_disallowed) {
         return;
     }
 

--- a/stage23/mm/pmm.h
+++ b/stage23/mm/pmm.h
@@ -57,4 +57,6 @@ void pmm_reclaim_uefi_mem(void);
 void pmm_release_uefi_mem(void);
 #endif
 
+bool pmm_allocation_allowed();
+
 #endif

--- a/stage23/mm/pmm.h
+++ b/stage23/mm/pmm.h
@@ -37,6 +37,8 @@ extern struct e820_entry_t *untouched_memmap;
 extern size_t untouched_memmap_entries;
 #endif
 
+extern bool allocations_disallowed;
+
 void init_memmap(void);
 struct e820_entry_t *get_memmap(size_t *entries);
 struct e820_entry_t *get_raw_memmap(size_t *entry_count);
@@ -56,7 +58,5 @@ void pmm_free(void *ptr, size_t length);
 void pmm_reclaim_uefi_mem(void);
 void pmm_release_uefi_mem(void);
 #endif
-
-bool pmm_allocation_allowed();
 
 #endif

--- a/stage23/mm/pmm.s2.c
+++ b/stage23/mm/pmm.s2.c
@@ -801,3 +801,7 @@ bool memmap_alloc_range(uint64_t base, uint64_t length, uint32_t type, bool free
 
     return false;
 }
+
+bool pmm_allocation_allowed(void) {
+    return !allocations_disallowed;
+}

--- a/stage23/mm/pmm.s2.c
+++ b/stage23/mm/pmm.s2.c
@@ -17,7 +17,7 @@
 extern symbol bss_end;
 #endif
 
-static bool allocations_disallowed = true;
+bool allocations_disallowed = true;
 static void sanitise_entries(struct e820_entry_t *, size_t *, bool);
 
 void *conv_mem_alloc(size_t count) {
@@ -800,8 +800,4 @@ bool memmap_alloc_range(uint64_t base, uint64_t length, uint32_t type, bool free
     }
 
     return false;
-}
-
-bool pmm_allocation_allowed(void) {
-    return !allocations_disallowed;
 }


### PR DESCRIPTION
See issue #140.
* Added makefile recipes to replicate issue more easily and test on legacy machines, on a DOS-readable image.
* Added crude print routine based on `int 10h, 0x0E`, in case stage 2 panic detects a recursive invocation.
* Made VGA textmode driver write directly to framebuffer, instead triple buffering, if the PMM does not allow allocations.

The VGA textmode driver fix will create artifacts, but it will only be invoked when a panic happens before the PMM is done initializing anyways, and it is enough to produce a readable panic screen.
The print routine in panic itself serves as a last line of defense, in case there is another circular dependency somewhere and does not produce a stack trace.