### PR TITLE
Specify the starting index of revision numbers

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -44,7 +44,7 @@ bootloader will scan for inside the executable file to find requests. Requests
 may be located anywhere inside the executable as long as they are 8-byte
 aligned. There may only be 1 of the same request. The bootloader will refuse
 to boot an executable with multiple of the same request IDs. Alternatively, it is possible to provide a list of requests explicitly via an executable file section. See "Limine Requests Section".
-* `revision` - The revision of the request that the kernel provides. This is
+* `revision` - The revision of the request that the kernel provides. This starts at 0 and is
 bumped whenever new members or functionality are added to the request structure.
 Bootloaders process requests in a backwards compatible manner, *always*. This
 means that if the bootloader does not support the revision of the request,


### PR DESCRIPTION
When I was reading this originally, I was a bit confused about what to set the revision numbers, as no "lowest version" was specified. I was only able to find this out by looking at the barebones example.

I think it might also be worth specifying revisions for each structure provided in the protocol specification, so that there is no confusion there.