### PR TITLE
deploy: allow non-positional --force-mbr

### DIFF
--- a/limine-deploy/limine-deploy.c
+++ b/limine-deploy/limine-deploy.c
@@ -316,8 +316,8 @@ static bool _device_write(const void *_buffer, uint64_t loc, size_t count) {
             goto cleanup;                       \
     } while (0)
 
-void usage() {
-    printf("Usage: %s <device> [GPT partition index]\n", argv[0]);
+void usage(const char *name) {
+    printf("Usage: %s <device> [GPT partition index]\n", name);
 #ifdef IS_WINDOWS
     system("pause");
 #endif
@@ -336,7 +336,7 @@ int main(int argc, char *argv[]) {
     bigendian = endbyte == 0x12;
 
     if (argc < 2) {
-        usage();
+        usage(argv[0]);
         goto cleanup;
     }
 
@@ -358,7 +358,7 @@ int main(int argc, char *argv[]) {
 
     if (device == NULL) {
         fprintf(stderr, "ERROR: No device specified\n");
-        usage();
+        usage(argv[0]);
         goto cleanup;
     }
 

--- a/limine-deploy/limine-deploy.c
+++ b/limine-deploy/limine-deploy.c
@@ -316,7 +316,7 @@ static bool _device_write(const void *_buffer, uint64_t loc, size_t count) {
             goto cleanup;                       \
     } while (0)
 
-void usage(const char *name) {
+static void usage(const char *name) {
     printf("Usage: %s <device> [GPT partition index]\n", name);
 #ifdef IS_WINDOWS
     system("pause");
@@ -537,9 +537,8 @@ int main(int argc, char *argv[]) {
     if (gpt == 0 && mbr == 0) {
         fprintf(stderr, "ERROR: Could not determine if the device has a valid partition table.\n");
         fprintf(stderr, "       Please ensure the device has a valid MBR or GPT.\n");
-        fprintf(stderr, "       Alternatively, pass `--force-mbr` at the end of the command to\n");
-        fprintf(stderr, "       override these checks. ONLY DO THIS AT YOUR OWN RISK, DATA LOSS\n");
-        fprintf(stderr, "       MAY OCCUR!\n");
+        fprintf(stderr, "       Alternatively, pass `--force-mbr` to override these checks. ONLY\n");
+        fprintf(stderr, "        DO THIS AT YOUR OWN RISK, DATA LOSS MAY OCCUR!\n");
         goto cleanup;
     }
 

--- a/limine-deploy/limine-deploy.c
+++ b/limine-deploy/limine-deploy.c
@@ -356,8 +356,8 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    if (!device) {
-        perror("ERROR: No device specified");
+    if (device == NULL) {
+        fprintf(stderr, "ERROR: No device specified\n");
         usage();
         goto cleanup;
     }
@@ -555,7 +555,7 @@ int main(int argc, char *argv[]) {
     uint64_t stage2_loc_b = stage2_loc_a + stage2_size_a;
 
     if (gpt) {
-        if (part_ndx) {
+        if (part_ndx != NULL) {
             uint32_t partition_num;
             sscanf(part_ndx, "%" SCNu32, &partition_num);
             partition_num--;

--- a/limine-deploy/limine-deploy.c
+++ b/limine-deploy/limine-deploy.c
@@ -347,7 +347,7 @@ int main(int argc, char *argv[]) {
             }
             force_mbr = 1;
         } else {
-            if (device) { // [GPT partition index]
+            if (device != NULL) { // [GPT partition index]
                 part_ndx = argv[i]; // TODO: Make this non-positional?
             } else if ((device = fopen(argv[i], "r+b")) == NULL) { // <device>
                 perror("ERROR");

--- a/limine-deploy/limine-deploy.c
+++ b/limine-deploy/limine-deploy.c
@@ -316,6 +316,13 @@ static bool _device_write(const void *_buffer, uint64_t loc, size_t count) {
             goto cleanup;                       \
     } while (0)
 
+void usage() {
+    printf("Usage: %s <device> [GPT partition index]\n", argv[0]);
+#ifdef IS_WINDOWS
+    system("pause");
+#endif
+}
+
 int main(int argc, char *argv[]) {
     int      ok = EXIT_FAILURE;
     int      force_mbr = 0;
@@ -329,10 +336,7 @@ int main(int argc, char *argv[]) {
     bigendian = endbyte == 0x12;
 
     if (argc < 2) {
-        printf("Usage: %s <device> [GPT partition index]\n", argv[0]);
-#ifdef IS_WINDOWS
-        system("pause");
-#endif
+        usage();
         goto cleanup;
     }
 
@@ -354,10 +358,7 @@ int main(int argc, char *argv[]) {
 
     if (!device) {
         perror("ERROR: No device specified");
-        printf("Usage: %s <device> [GPT partition index]\n", argv[0]);
-#ifdef IS_WINDOWS
-        system("pause");
-#endif
+        usage();
         goto cleanup;
     }
 


### PR DESCRIPTION
Improvement on #182; fixed formatting, added comments, and made `[GPT partition index]` not fixed at `argv[2]` either. Incidentally, this allows `--force-mbr` and `[GPT partition index]` to coexist; there may be cause for a check for this.