### PR TITLE
limine: guarantee that SMP `goto_address` is initialized to NULL

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -606,7 +606,8 @@ jump to the written address, on a 64KiB (or Stack Size Request size) stack. A po
 `struct limine_smp_info` structure of the CPU is passed in `RDI`. Other than
 that, the CPU state will be the same as described for the bootstrap
 processor. This field is unused for the structure describing the bootstrap
-processor.
+processor. For all CPUs, this field is guaranteed to be NULL when control is first passed
+to the bootstrap processor.
 * `extra_argument` - A free for use field.
 
 ### Memory Map Feature


### PR DESCRIPTION
Guaranteeing that this field will be NULL gives kernels a way to reliably check if they've already run code to start up a given CPU. Limine already does this by nature of its memory allocator, so no changes are needed to the bootloader itself.