### PR TITLE
misc: Fix GRAPHICS config option recognition

### DIFF
--- a/common/menu.c
+++ b/common/menu.c
@@ -708,7 +708,7 @@ static noreturn void _menu(bool timeout_enabled) {
 #endif
 
 reterm:
-    if (graphics == NULL || strcmp(graphics, "no") == 1) {
+    if (graphics == NULL || strcmp(graphics, "no") != 0) {
         size_t req_width = 0, req_height = 0, req_bpp = 0;
 
         char *menu_resolution = config_get_value(NULL, 0, "INTERFACE_RESOLUTION");


### PR DESCRIPTION
`strcmp()` returns any non-zero value when strings differ, not necessarily 1.