### PR TITLE
common: fix alignment of variable in AArch64 menu thunk

### DIFF
--- a/common/menu_thunk.asm_aarch64
+++ b/common/menu_thunk.asm_aarch64
@@ -1,5 +1,6 @@
 .section .data
 
+.align 3
 stack_at_first_entry:
     .quad 0
 


### PR DESCRIPTION
Fixes a problem that sometimes occured due to a specific relocation
being used for the misaligned variable.