### PR TITLE
protocol: `dtb_ptr` should be a virtual pointer

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1077,7 +1077,7 @@ struct limine_dtb_response {
 };
 ```
 
-* `dtb_ptr` - Physical pointer to the device tree blob.
+* `dtb_ptr` - Virtual pointer to the device tree blob.
 
 Note: Information contained in the `/chosen` node may not reflect the information
 given by bootloader tags, and as such the `/chosen` node properties should be ignored.


### PR DESCRIPTION
* The `dtb_ptr` is a virtual pointer not a physical pointer (since the code calls `reported_addr` on it).

Signed-off-by: Andy-Python-Programmer <andypythonappdeveloper@gmail.com>