### PR TITLE
DTB: ensure the `dtb_ptr` is an HHDM address

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1079,5 +1079,7 @@ struct limine_dtb_response {
 
 * `dtb_ptr` - Virtual pointer to the device tree blob.
 
+Note: If the DTB cannot be found, the response will *not* be generated.
+
 Note: Information contained in the `/chosen` node may not reflect the information
 given by bootloader tags, and as such the `/chosen` node properties should be ignored.


### PR DESCRIPTION
* Ensure that the `dtb_ptr` is an HHDM address
* If DTB is not found, do not generate the response
* Allocate the response only if required.

Signed-off-by: Andy-Python-Programmer <andypythonappdeveloper@gmail.com>