### PR TITLE
readline: Fix command line scrolling and cursor wrap-around

### DIFF
--- a/common/lib/readline.c
+++ b/common/lib/readline.c
@@ -377,9 +377,11 @@ static void cursor_fwd(void) {
     term->get_cursor_pos(term, &x, &y);
     if (x < term->cols - 1) {
         x++;
-    } else if (y < term->rows - 1) {
-        y++;
+    } else {
         x = 0;
+        if (y < term->rows - 1) {
+            y++;
+        }
     }
     set_cursor_pos_helper(x, y);
 }
@@ -457,8 +459,15 @@ void readline(const char *orig_str, char *buf, size_t limit) {
                     }
                     buf[i] = c;
                     i++;
+                    size_t prev_x, prev_y;
+                    term->get_cursor_pos(term, &prev_x, &prev_y);
                     cursor_fwd();
                     reprint_string(orig_x, orig_y, buf);
+                    // If cursor has wrapped around, move the line start position up one row
+                    if (prev_x == term->cols - 1 && prev_y == term->rows - 1) {
+                        orig_y--;
+                        print("\e[J");  // Clear the bottom line
+                    }
                 }
             }
         }


### PR DESCRIPTION
I recently fixed 2 bugs in the Limine console. They are both included in this pull request, as they are somewhat related. I can separate them into 2 different pull requests if you would prefer.

I really enjoy the bootloader by the way. I hope this bug fix is helpful. :D

## To Reproduce

This can be reproduced on any Limine version that includes the console feature (tested on Limine v4.20221112.0). UEFI and BIOS are both affected.

Preconditions after entering the Limine console:

1. The command line is positioned at the bottom of the screen
2. The user inputs enough characters so that the cursor is positioned at the bottom right corner of the screen

When these preconditions are true, the screen would look something like this:

![Pre-Wrap](https://user-images.githubusercontent.com/76848730/201546138-24922a48-fcbe-40e7-9b82-5aaa3847c6b9.png)

Any subsequent keypresses trigger both bugs. The next 3 images show what the screen looks like after 3 subsequent keypresses (each time pressing the 'b' key):

![Post-Wrap1](https://user-images.githubusercontent.com/76848730/201546237-f2f3097e-f719-4c18-a1cc-75b161d86cef.png)
![Post-Wrap2](https://user-images.githubusercontent.com/76848730/201546239-d9075283-13ea-46ac-8731-044eabab6cab.png)
![Post-Wrap3](https://user-images.githubusercontent.com/76848730/201546240-ed3edf68-f20a-4872-aa95-7290356c29b4.png)

After enough keypresses, the multiline command is copied enough times to fill the entire screen:

![Post-Wrap4](https://user-images.githubusercontent.com/76848730/201546247-f80285cc-d563-4f42-93e4-bd635b1cab44.png)

## Causes

There are 2 separate causes for this behavior:

1. When the command becomes too large to fit on one line (and the line is at the bottom), the screen scrolls up, but the internal line starting position (`orig_y` in `readline()`) does not move up with it. Any subsequent keypress causes the multi-line command to be re-printed, still starting from the bottom row. This causes the screen to scroll up one row for each keypress
2. The cursor does not wrap around to the start of the line when it passes the bottom right corner

## Fixes

Fixing these bugs wasn't too difficult once I figured out the root causes.

The fixes contained in this patch are:

1. The internal line start position is moved up by 1 row when the screen is scrolled up
2. The cursor's column position wraps around to the start when the command line is at the bottom row

## Proper Behavior

With this patch, the cursor is fixed to wrap around properly and the scrolling is fixed to only be triggered once.

Here is an image showing the proper behavior when the steps shown above are followed:

![Fixed-Bug](https://user-images.githubusercontent.com/76848730/201546105-c8c98fc4-e391-43c4-bc98-12dd38f632c1.png)

## Additional Context

I have tested this patch to fix the bugs on UEFI and BIOS x86_64 (QEMU and hardware).
