### PR TITLE
Fixed little memory leak in the UEFI build

### DIFF
--- a/common/drivers/disk.s2.c
+++ b/common/drivers/disk.s2.c
@@ -648,15 +648,18 @@ fail:
 
         volume_index[volume_index_i++] = block;
 
+        struct volume _p;
         for (int part = 0; ; part++) {
-            struct volume *p = ext_mem_alloc(sizeof(struct volume));
-            int ret = part_get(p, block, part);
+
+            int ret = part_get(&_p, block, part);
 
             if (ret == END_OF_TABLE || ret == INVALID_TABLE)
                 break;
             if (ret == NO_PARTITION)
                 continue;
 
+            struct volume *p = ext_mem_alloc(sizeof(struct volume));
+            memcpy(p, &_p, sizeof(struct volume));
             volume_index[volume_index_i++] = p;
 
             block->max_partition++;


### PR DESCRIPTION
this pr fixes a bug that would make the bootloader crash on systems with larger disks.
this is because when scanning for partitions, it would keep allocating volume structures, even when it didn't find any partition, and not clean them up.