### PR TITLE
pmm: Add EFI runtime mmap type

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -811,6 +811,7 @@ struct limine_memmap_response {
 #define LIMINE_MEMMAP_BOOTLOADER_RECLAIMABLE 5
 #define LIMINE_MEMMAP_KERNEL_AND_MODULES     6
 #define LIMINE_MEMMAP_FRAMEBUFFER            7
+#define LIMINE_MEMMAP_EFI_RUNTIME            8
 
 struct limine_memmap_entry {
     uint64_t base;

--- a/common/mm/pmm.h
+++ b/common/mm/pmm.h
@@ -21,6 +21,7 @@ struct memmap_entry {
 #define MEMMAP_KERNEL_AND_MODULES     0x1001
 #define MEMMAP_FRAMEBUFFER            0x1002
 #define MEMMAP_EFI_RECLAIMABLE        0x2000
+#define MEMMAP_EFI_RUNTIME            0x2001
 
 struct meminfo {
     size_t uppermem;

--- a/common/mm/pmm.s2.c
+++ b/common/mm/pmm.s2.c
@@ -330,8 +330,6 @@ void init_memmap(void) {
         uint32_t our_type;
         switch (entry->Type) {
             case EfiReservedMemoryType:
-            case EfiRuntimeServicesCode:
-            case EfiRuntimeServicesData:
             case EfiUnusableMemory:
             case EfiMemoryMappedIO:
             case EfiMemoryMappedIOPortSpace:
@@ -349,6 +347,9 @@ void init_memmap(void) {
                 our_type = MEMMAP_ACPI_NVS; break;
             case EfiConventionalMemory:
                 our_type = MEMMAP_USABLE; break;
+            case EfiRuntimeServicesCode:
+            case EfiRuntimeServicesData:
+                our_type = MEMMAP_EFI_RUNTIME; break;
         }
 
         uint64_t base = entry->PhysicalStart;

--- a/common/protos/limine.c
+++ b/common/protos/limine.c
@@ -1034,6 +1034,9 @@ FEAT_START
             case MEMMAP_FRAMEBUFFER:
                 _memmap[i].type = LIMINE_MEMMAP_FRAMEBUFFER;
                 break;
+            case MEMMAP_EFI_RUNTIME:
+                _memmap[i].type = LIMINE_MEMMAP_EFI_RUNTIME;
+                break;
             default:
             case MEMMAP_RESERVED:
                 _memmap[i].type = LIMINE_MEMMAP_RESERVED;

--- a/limine.h
+++ b/limine.h
@@ -300,6 +300,7 @@ struct limine_smp_request {
 #define LIMINE_MEMMAP_BOOTLOADER_RECLAIMABLE 5
 #define LIMINE_MEMMAP_KERNEL_AND_MODULES     6
 #define LIMINE_MEMMAP_FRAMEBUFFER            7
+#define LIMINE_MEMMAP_EFI_RUNTIME            8
 
 struct limine_memmap_entry {
     uint64_t base;


### PR DESCRIPTION
For possible use in EFI runtime services SetVirtualAddressMap.