### PR TITLE
limine: Add an arch tag to simplify multi-arch netboot

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -95,9 +95,11 @@ Editor control options.
 * `EDITOR_VALIDATION` - If set to `no`, the editor will not alert you about invalid keys / syntax errors. Defaults to `yes`.
 
 *Locally assignable (non protocol specific)* keys are:
+* `ARCH` - The architecture of the kernel/executable. Valid architectures are: `i386`, `x86_64`, and `aarch64`. 
 * `COMMENT` - An optional comment string that will be displayed by the bootloader on the menu when an entry is selected.
 * `PROTOCOL` - The boot protocol that will be used to boot the kernel. Valid protocols are: `linux`, `limine`, `chainload`, `chainload_next`, `multiboot` (or `multiboot1`), and `multiboot2`.
 * `CMDLINE` - The command line string to be passed to the kernel/executable. Can be omitted.
+* `KERNEL_ARCH` - Alias of `ARCH`.
 * `KERNEL_CMDLINE` - Alias of `CMDLINE`.
 
 *Locally assignable (protocol specific)* keys are:

--- a/common/lib/config.c
+++ b/common/lib/config.c
@@ -98,20 +98,25 @@ static struct menu_entry *create_menu_tree(struct menu_entry *parent,
                 break;
         }
 
-        struct menu_entry *entry = ext_mem_alloc(sizeof(struct menu_entry));
+        size_t entry_size;
+        char *config_entry = config_get_entry(&entry_size, i);
 
+        const char *arch = config_get_value(config_entry, 0, "KERNEL_ARCH");
+        if (arch == NULL)
+            arch = config_get_value(config_entry, 0, "ARCH");
+        if (arch != NULL && strcmp(arch, get_arch_name()) != 0)
+                continue;
+
+        struct menu_entry *entry = ext_mem_alloc(sizeof(struct menu_entry));
         if (root == NULL)
             root = entry;
 
         config_get_entry_name(name, i, 64);
-
         bool default_expanded = name[current_depth] == '+';
 
         strcpy(entry->name, name + current_depth + default_expanded);
         entry->parent = parent;
 
-        size_t entry_size;
-        char *config_entry = config_get_entry(&entry_size, i);
         entry->body = ext_mem_alloc(entry_size + 1);
         memcpy(entry->body, config_entry, entry_size);
         entry->body[entry_size] = 0;

--- a/common/lib/misc.c
+++ b/common/lib/misc.c
@@ -21,6 +21,20 @@ UINT32 efi_desc_ver = 0;
 
 bool editor_enabled = true;
 
+const char *get_arch_name(void) {
+#ifdef __i386__
+    return "i386";
+#elif defined (__x86_64__)
+    return "x86_64";
+#elif defined (__aarch64__)
+    return "aarch64";
+#elif defined (__riscv64)
+    return "riscv64";
+#else
+    #error "Unknown architecture"
+#endif
+}
+
 bool parse_resolution(size_t *width, size_t *height, size_t *bpp, const char *buf) {
     size_t res[3] = {0};
 

--- a/common/lib/misc.h
+++ b/common/lib/misc.h
@@ -38,6 +38,8 @@ extern bool stage3_loaded;
 
 extern bool quiet, serial, editor_enabled, hash_mismatch_panic;
 
+const char *get_arch_name(void);
+
 bool parse_resolution(size_t *width, size_t *height, size_t *bpp, const char *buf);
 
 void get_absolute_path(char *path_ptr, const char *path, const char *pwd);

--- a/common/menu.c
+++ b/common/menu.c
@@ -84,9 +84,11 @@ static size_t get_prev_line(size_t index, const char *buffer) {
 }
 
 static const char *VALID_KEYS[] = {
+    "ARCH",
     "COMMENT",
     "PROTOCOL",
     "CMDLINE",
+    "KERNEL_ARCH",
     "KERNEL_CMDLINE",
     "KERNEL_PATH",
     "INITRD_PATH",


### PR DESCRIPTION
As I mentioned on the Discord, there's no easy way to automatically netboot multiple architectures from one PXE server, as there's no way to specify per-arch tftp root directories (at least with dnsmasq's bootp/tftp implementation), which would limit one to a singular `limine.cfg`. This PR adds an ARCH tag (with KERNEL_ARCH as an alias) so that limine can filter out incompatible kernels.