### PR TITLE
multiboot2: Support TEXTMODE config as with linux

### DIFF
--- a/common/protos/multiboot2.c
+++ b/common/protos/multiboot2.c
@@ -521,6 +521,15 @@ noreturn void multiboot2_load(char *config, char* cmdline) {
         size_t req_width = 0;
         size_t req_height = 0;
         size_t req_bpp = 0;
+#if defined (BIOS)
+        {
+            char *textmode_str = config_get_value(config, 0, "TEXTMODE");
+            bool textmode = textmode_str != NULL && strcmp(textmode_str, "yes") == 0;
+            if (textmode) {
+                goto textmode;
+            }
+        }
+#endif
 
         if (fbtag) {
             req_width = fbtag->width;


### PR DESCRIPTION
Cribbing off the implementation in `common/protos/linux.c`, this adds support for the `TEXTMODE` config variable with Multiboot2. This is useful if a kernel provides a framebuffer header tag with a preferred mode (preventing text mode from being enabled unless no framebuffer can be configured), but a user would like to use text mode anyway (perhaps for debugging, or out of a sense of nostalgia).

As with the existing implementation for Linux, this config value is only checked in BIOS configurations - no attempt is made to examine it under EFI or report an error in that case.