### PR TITLE
Fix PXE BIOS boot when using a proxy DHCP server

### DIFF
--- a/common/pxe/pxe.h
+++ b/common/pxe/pxe.h
@@ -88,6 +88,7 @@ struct bangpxe {
 } __attribute__((packed));
 
 #define PXENV_GET_CACHED_INFO 0x0071
+#define PXENV_PACKET_TYPE_CACHED_REPLY 3
 struct pxenv_get_cached_info {
     uint16_t status;
     uint16_t packet_type;

--- a/common/pxe/tftp.s2.c
+++ b/common/pxe/tftp.s2.c
@@ -14,7 +14,7 @@
 
 static uint32_t get_boot_server_info(void) {
     struct pxenv_get_cached_info cachedinfo = { 0 };
-    cachedinfo.packet_type = 2;
+    cachedinfo.packet_type = PXENV_PACKET_TYPE_CACHED_REPLY;
     pxe_call(PXENV_GET_CACHED_INFO, ((uint16_t)rm_seg(&cachedinfo)), (uint16_t)rm_off(&cachedinfo));
     struct bootph *ph = (struct bootph*)(void *) (((((uint32_t)cachedinfo.buffer) >> 16) << 4) + (((uint32_t)cachedinfo.buffer) & 0xFFFF));
     return ph->sip;


### PR DESCRIPTION
PXE BIOS boot did not work when using a proxy DHCP server. This simple change to use the cached reply instead of the DHCP ACK (which `2` requested) fixes it, and does not break booting in QEMU. I added a define so there's no longer a magic number as well.