### PR TITLE
Implement UEFI serial protocol and add baudrate configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /common/flanterm
 /common/stb/stb_image.h
 /ovmf*
+compile_commands.json
 *.o
 *.d
 *.a

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -56,6 +56,7 @@ Some keys take *URIs* as values; these are described in the next section.
 * `TIMEOUT` - Specifies the timeout in seconds before the first *entry* is automatically booted. If set to `no`, disable automatic boot. If set to `0`, boots default entry instantly (see `DEFAULT_ENTRY` key).
 * `QUIET` - If set to `yes`, enable quiet mode, where all screen output except panics and important warnings is suppressed. If `TIMEOUT` is not 0, the `TIMEOUT` still occurs, and pressing any key during the timeout will reveal the menu and disable quiet mode.
 * `SERIAL` - If set to `yes`, enable serial I/O for the bootloader.
+* `SERIAL_BAUDRATE` - If `SERIAL` is set to `yes`, this specifies the baudrate to use for serial I/O. Defaults to `9600`.
 * `DEFAULT_ENTRY` - 1-based entry index of the entry which will be automatically selected at startup. If unspecified, it is `1`.
 * `GRAPHICS` - If set to `no`, force CGA text mode for the boot menu, else use a video mode. Ignored with Limine UEFI.
 * `VERBOSE` - If set to `yes`, print additional information during boot. Defaults to not verbose.

--- a/common/drivers/serial.h
+++ b/common/drivers/serial.h
@@ -1,13 +1,13 @@
 #ifndef __DRIVERS__SERIAL_H__
 #define __DRIVERS__SERIAL_H__
 
-#if defined (BIOS)
-
+#include <stdbool.h>
 #include <stdint.h>
+
+extern bool serial;
+extern int serial_baudrate;
 
 void serial_out(uint8_t b);
 int serial_in(void);
-
-#endif
 
 #endif

--- a/common/drivers/serial.s2.c
+++ b/common/drivers/serial.s2.c
@@ -1,46 +1,134 @@
-#if defined (BIOS)
-
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
 #include <drivers/serial.h>
 #include <sys/cpu.h>
 #include <lib/misc.h>
+#include <lib/print.h>
+
+bool serial = false;
+int serial_baudrate = 9600;
 
 static bool serial_initialised = false;
+static bool uart_is_16550 = false;
+
+#if defined(UEFI)
+EFI_SERIAL_IO_PROTOCOL *serial_io_protocol;
+#endif
+
+// In theory this could be used anywhere that implements a 16550 UART, but would need to be adapted to MMIO
+static void uart16550_initialise(void) {
+    if (serial_initialised) {
+        return;
+    }
+
+#if defined(__i386__) || defined(__x86_64__)
+    // Init com1
+    outb(0x3f8 + 3, 0x00);
+    outb(0x3f8 + 1, 0x00);
+    outb(0x3f8 + 3, 0x80);
+
+    uint16_t divisor =  (uint16_t)(115200 / serial_baudrate);
+    outb(0x3f8 + 0, divisor & 0xff);
+    outb(0x3f8 + 1, (divisor >> 8) & 0xff);
+
+    outb(0x3f8 + 3, 0x03);
+    outb(0x3f8 + 2, 0xc7);
+    outb(0x3f8 + 4, 0x0b);
+#endif
+
+    serial_initialised = true;
+    uart_is_16550 = true;
+}
 
 static void serial_initialise(void) {
     if (serial_initialised) {
         return;
     }
 
-    // Init com1
-    outb(0x3f8 + 3, 0x00);
-    outb(0x3f8 + 1, 0x00);
-    outb(0x3f8 + 3, 0x80);
-    outb(0x3f8 + 0, 0x0c); // 9600 baud
-    outb(0x3f8 + 1, 0x00);
-    outb(0x3f8 + 3, 0x03);
-    outb(0x3f8 + 2, 0xc7);
-    outb(0x3f8 + 4, 0x0b);
+#if defined(UEFI)
+    EFI_STATUS status;
+    EFI_GUID serial_io_protocol_guid = EFI_SERIAL_IO_PROTOCOL_GUID;
+
+    status = gBS->LocateProtocol(&serial_io_protocol_guid, NULL, (void **)&serial_io_protocol);
+    if (status) {
+        uart16550_initialise();
+        print("Could not get serial io protocol, defaulting to 16550 style uart\n");
+        return;
+    }
+
+	// 0 indicates hardware defaults
+    status = serial_io_protocol->SetAttributes(serial_io_protocol, serial_baudrate, 0, 0, 0, 0, 0);
+    if (status) {
+        panic(false, "Could not set serial attributes");
+    }
+
+    status = serial_io_protocol->Reset(serial_io_protocol);
+    if (status) {
+        panic(false, "Could not reset serial io protocol");
+    }
 
     serial_initialised = true;
+    return;
+#else
+    uart16550_initialise();
+#endif
 }
 
 void serial_out(uint8_t b) {
     serial_initialise();
 
+#if defined(UEFI)
+    if (!uart_is_16550) {
+        uint8_t buffer[] = {b, 0};
+        UINTN buffer_size = 1;
+        EFI_STATUS ret = serial_io_protocol->Write(serial_io_protocol, &buffer_size, buffer);
+        if (ret) {
+            panic(false, "Could not write to serial port");
+        }
+        return;
+    }
+#endif
+
+#if defined(__i386__) || defined(__x86_64__)
     while ((inb(0x3f8 + 5) & 0x20) == 0);
     outb(0x3f8, b);
+#endif
 }
 
 int serial_in(void) {
     serial_initialise();
 
+#if defined(UEFI)
+    if (!uart_is_16550) {
+        EFI_STATUS ret;
+        uint32_t status;
+        ret = serial_io_protocol->GetControl(serial_io_protocol, &status);
+        if (ret) {
+            panic(false, "Could not get serial control");
+        }
+
+        if ((status & EFI_SERIAL_INPUT_BUFFER_EMPTY) != 0) {
+            return -1;
+        }
+
+        uint8_t buffer[1];
+        UINTN buffer_size = 1;
+        ret = serial_io_protocol->Read(serial_io_protocol, &buffer_size, buffer);
+        if (ret) {
+            panic(false, "Could not read from serial port");
+        }
+
+        return buffer[0];
+    }
+#endif
+
+#if defined(__i386__) || defined(__x86_64__)
     if ((inb(0x3f8 + 5) & 0x01) == 0) {
         return -1;
     }
     return inb(0x3f8);
-}
-
 #endif
+
+    return -1;
+}

--- a/common/drivers/vga_textmode.c
+++ b/common/drivers/vga_textmode.c
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
+#include <drivers/serial.h>
 #include <drivers/vga_textmode.h>
 #include <sys/cpu.h>
 #include <lib/real.h>

--- a/common/lib/gterm.c
+++ b/common/lib/gterm.c
@@ -1,5 +1,6 @@
 #include <stdint.h>
 #include <stddef.h>
+#include <drivers/serial.h>
 #include <lib/gterm.h>
 #include <lib/misc.h>
 #include <lib/libc.h>

--- a/common/lib/misc.h
+++ b/common/lib/misc.h
@@ -33,7 +33,7 @@ extern struct volume *boot_volume;
 extern bool stage3_loaded;
 #endif
 
-extern bool quiet, serial, editor_enabled, hash_mismatch_panic;
+extern bool quiet, editor_enabled, hash_mismatch_panic;
 
 bool parse_resolution(size_t *width, size_t *height, size_t *bpp, const char *buf);
 

--- a/common/lib/misc.s2.c
+++ b/common/lib/misc.s2.c
@@ -5,7 +5,6 @@
 
 bool verbose = false;
 bool quiet = false;
-bool serial = false;
 bool hash_mismatch_panic = false;
 
 uint8_t bcd_to_int(uint8_t val) {

--- a/common/lib/print.s2.c
+++ b/common/lib/print.s2.c
@@ -236,7 +236,6 @@ out:
             outb(0xe9, print_buf[i]);
         }
 #endif
-#if defined (BIOS)
         if ((!quiet && serial) || COM_OUTPUT) {
             switch (print_buf[i]) {
                 case '\n':
@@ -252,6 +251,5 @@ out:
             }
             serial_out(print_buf[i]);
         }
-#endif
     }
 }

--- a/common/lib/readline.c
+++ b/common/lib/readline.c
@@ -304,7 +304,6 @@ again:
         if (ret != 0) {
             return ret;
         }
-        goto again;
     }
 
     memset(&kd, 0, sizeof(EFI_KEY_DATA));

--- a/common/menu.c
+++ b/common/menu.c
@@ -13,6 +13,7 @@
 #include <lib/readline.h>
 #include <lib/uri.h>
 #include <mm/pmm.h>
+#include <drivers/serial.h>
 #include <drivers/vbe.h>
 #include <drivers/vga_textmode.h>
 #include <console.h>
@@ -652,6 +653,17 @@ noreturn void _menu(bool first_run) {
 
     char *serial_str = config_get_value(NULL, 0, "SERIAL");
     serial = serial_str != NULL && strcmp(serial_str, "yes") == 0;
+
+    // If serial is enabled, we should check for baud rate
+    if (serial) {
+        char *baud_str = config_get_value(NULL, 0, "SERIAL_BAUDRATE");
+        if (baud_str != NULL) {
+            int baud = strtoui(baud_str, NULL, 10);
+            if (baud > 0) {
+                serial_baudrate = baud;
+            }
+        }
+    }
 
     char *hash_mismatch_panic_str = config_get_value(NULL, 0, "HASH_MISMATCH_PANIC");
     hash_mismatch_panic = hash_mismatch_panic_str == NULL || strcmp(hash_mismatch_panic_str, "yes") == 0;

--- a/common/protos/limine.c
+++ b/common/protos/limine.c
@@ -769,7 +769,6 @@ FEAT_START
     struct limine_terminal *terminal = ext_mem_alloc(sizeof(struct limine_terminal));
 
     quiet = false;
-    serial = false;
 
     char *term_conf_override_s = config_get_value(config, 0, "TERM_CONFIG_OVERRIDE");
     if (term_conf_override_s != NULL && strcmp(term_conf_override_s, "yes") == 0) {

--- a/common/sys/cpu.h
+++ b/common/sys/cpu.h
@@ -227,6 +227,12 @@ inline uint64_t rdtsc(void) {
     return v;
 }
 
+inline void delay(uint64_t cycles) {
+    uint64_t next_stop = rdtsc() + cycles;
+
+    while (rdtsc() < next_stop);
+}
+
 #define locked_read(var) ({ \
     typeof(*var) locked_read__ret = 0; \
     asm volatile ( \


### PR DESCRIPTION
This is implemented in such a way that it will fallback to the normal serial port if the serial io protocol is not found. Baudrate still defaults to 9660. I also included a note about potentially extending serial support to devices with 16550 style UARTs, probably by adding config options to specify an MMIO base and register width. I also moved the serial boolean to the driver, I think it makes more sense there than in misc.c. Finally, I added an entry to .gitignore for my future convenience, I use a tool called compiledb to generate said file to improve my experience using VSCode

I realized I neglected to change readline to use serial on UEFI systems. The additions are in the second commit, it's not the cleanest implementation in the world and I'm open to suggestions to improve it.