### PR TITLE
multiboot2: fix 32 bit elf section loading

### DIFF
--- a/common/lib/elf.c
+++ b/common/lib/elf.c
@@ -76,19 +76,6 @@ struct elf32_phdr {
     uint32_t p_align;
 };
 
-struct elf32_shdr {
-    uint32_t sh_name;
-    uint32_t sh_type;
-    uint32_t sh_flags;
-    uint32_t sh_addr;
-    uint32_t sh_offset;
-    uint32_t sh_size;
-    uint32_t sh_link;
-    uint32_t sh_info;
-    uint32_t sh_addralign;
-    uint32_t sh_entsize;
-};
-
 struct elf64_rela {
     uint64_t r_addr;
     uint32_t r_info;

--- a/common/lib/elf.h
+++ b/common/lib/elf.h
@@ -69,6 +69,19 @@ struct elf64_shdr {
     uint64_t sh_entsize;
 };
 
+struct elf32_shdr {
+    uint32_t sh_name;
+    uint32_t sh_type;
+    uint32_t sh_flags;
+    uint32_t sh_addr;
+    uint32_t sh_offset;
+    uint32_t sh_size;
+    uint32_t sh_link;
+    uint32_t sh_info;
+    uint32_t sh_addralign;
+    uint32_t sh_entsize;
+};
+
 struct elf64_sym {
     uint32_t st_name;
     uint8_t  st_info;


### PR DESCRIPTION
Existing code was using 64 bit elf section header unconditionally. This commit fixes that :)