### PR TITLE
multiboot1: also fix elf32 section loading

### DIFF
--- a/common/protos/multiboot1.c
+++ b/common/protos/multiboot1.c
@@ -212,22 +212,42 @@ noreturn void multiboot1_load(char *config, char *cmdline) {
 
         memcpy(sections, kernel + section_hdr_info.section_offset, section_hdr_info.section_entry_size * section_hdr_info.num);
 
+        int bits = elf_bits(kernel);
+
         for (size_t i = 0; i < section_hdr_info.num; i++) {
-            struct elf64_shdr *shdr = (void *)sections + i * section_hdr_info.section_entry_size;
+            if (bits == 64) {
+                struct elf64_shdr *shdr = (void *)sections + i * section_hdr_info.section_entry_size;
 
-            if (shdr->sh_addr != 0 || shdr->sh_size == 0) {
-                continue;
+                if (shdr->sh_addr != 0 || shdr->sh_size == 0) {
+                    continue;
+                }
+
+                uint64_t section = (uint64_t)-1; /* no target preference, use top */
+
+                if (!elsewhere_append(true /* flexible target */,
+                        ranges, &ranges_count,
+                        kernel + shdr->sh_offset, &section, shdr->sh_size)) {
+                    panic(true, "multiboot1: Cannot allocate elf sections");
+                }
+
+                shdr->sh_addr = section;
+            } else {
+                struct elf32_shdr *shdr = (void *)sections + i * section_hdr_info.section_entry_size;
+
+                if (shdr->sh_addr != 0 || shdr->sh_size == 0) {
+                    continue;
+                }
+
+                uint64_t section = (uint64_t)-1; /* no target preference, use top */
+
+                if (!elsewhere_append(true /* flexible target */,
+                        ranges, &ranges_count,
+                        kernel + shdr->sh_offset, &section, shdr->sh_size)) {
+                    panic(true, "multiboot1: Cannot allocate elf sections");
+                }
+                        
+                shdr->sh_addr = section;
             }
-
-            uint64_t section = (uint64_t)-1; /* no target preference, use top */
-
-            if (!elsewhere_append(true /* flexible target */,
-                    ranges, &ranges_count,
-                    kernel + shdr->sh_offset, &section, shdr->sh_size)) {
-                panic(true, "multiboot1: Cannot allocate elf sections");
-            }
-
-            shdr->sh_addr = section;
         }
 
         multiboot1_info->flags |= (1 << 5);


### PR DESCRIPTION
As with the prior mb2 fix, use the correct size elf section header for 32 bit elf