### PR TITLE
limine: scale the maximum KASLR offset based on the address space size

### DIFF
--- a/common/mm/vmm.c
+++ b/common/mm/vmm.c
@@ -273,6 +273,19 @@ uint64_t paging_mode_higher_half(int paging_mode) {
     }
 }
 
+int paging_mode_va_bits(int paging_mode) {
+    switch (paging_mode) {
+        case PAGING_MODE_RISCV_SV39:
+            return 39;
+        case PAGING_MODE_RISCV_SV48:
+            return 48;
+        case PAGING_MODE_RISCV_SV57:
+            return 57;
+        default:
+            panic(false, "paging_mode_va_bits: invalid mode");
+    }
+}
+
 int vmm_max_paging_mode(void)
 {
     static int max_level;

--- a/common/mm/vmm.h
+++ b/common/mm/vmm.h
@@ -15,6 +15,8 @@
 #define PAGING_MODE_X86_64_4LVL 0
 #define PAGING_MODE_X86_64_5LVL 1
 
+#define paging_mode_va_bits(mode) ((mode) ? 57 : 48)
+
 static inline uint64_t paging_mode_higher_half(int paging_mode) {
     if (paging_mode == PAGING_MODE_X86_64_5LVL) {
         return 0xff00000000000000;
@@ -88,6 +90,8 @@ void map_page(pagemap_t pagemap, uint64_t virt_addr, uint64_t phys_addr, uint64_
 #define PAGING_MODE_RISCV_SV39 8
 #define PAGING_MODE_RISCV_SV48 9
 #define PAGING_MODE_RISCV_SV57 10
+
+int paging_mode_va_bits(int paging_mode);
 
 enum page_size {
     Size4KiB,

--- a/common/protos/limine.c
+++ b/common/protos/limine.c
@@ -194,7 +194,8 @@ static void **requests;
 static void set_paging_mode(int paging_mode, bool kaslr) {
     direct_map_offset = paging_mode_higher_half(paging_mode);
     if (kaslr) {
-        direct_map_offset += (rand64() & ~((uint64_t)0x40000000 - 1)) & 0xfffffffffff;
+        uint64_t mask = ((uint64_t)1 << (paging_mode_va_bits(paging_mode) - 4)) - 1;
+        direct_map_offset += (rand64() & ~((uint64_t)0x40000000 - 1)) & mask;
     }
 }
 


### PR DESCRIPTION
This fixes KASLR on RISC-V with Sv39 paging. Currently it is possible for too large of an offset to be applied, overflowing the addresses reported to kernels.