### PR TITLE
Implement new E820 sanitizer

### DIFF
--- a/common/mm/pmm.s2.c
+++ b/common/mm/pmm.s2.c
@@ -52,6 +52,10 @@ void *conv_mem_alloc(size_t count) {
 
 struct memmap_entry memmap[memmap_max_entries];
 size_t memmap_entries = 0;
+
+struct memmap_entry *overlap_map[2 * memmap_max_entries];
+struct memmap_entry clean_map[memmap_max_entries];
+struct memmap_entry new_map[memmap_max_entries];
 #endif
 
 #if defined (UEFI)
@@ -198,11 +202,6 @@ int split_overlaps(struct memmap_entry *dst, struct memmap_entry *p1, struct mem
 }
 
 static void sanitise_entries(struct memmap_entry *m, size_t *_count, bool align_entries) {
-#if defined (BIOS)
-    struct memmap_entry *overlap_map[2 * memmap_max_entries];
-    struct memmap_entry clean_map[memmap_max_entries];
-    struct memmap_entry new_map[memmap_max_entries];
-#endif
     struct memmap_entry tmp;
 
     size_t count;

--- a/common/mm/pmm.s2.c
+++ b/common/mm/pmm.s2.c
@@ -264,6 +264,13 @@ static void sanitise_entries(struct memmap_entry *m, size_t *_count, bool align_
         }
     }
 
+    for(size_t i = 0; align_entries && i < new_count; i++) {
+        // Don't bother aligning unusable entries
+        if(!bad_entry_type(m[i].type) ) {
+            align_entry(&m[i].base, &m[i].length);
+        }
+    }
+
     *_count = new_count;
     memcpy(m, new_map, sizeof(*m) * new_count);
 


### PR DESCRIPTION
This pull request implements a new E820 memory map sanitisation algorithm, which
deals with three-way splits and type precedence. A complete description can be
found in commit 5eafe5d4 and 4d832f0c. The summary is:

    - sort the E820 memory map entries
    - map all overlapping/adjacent entries
    - merge overlapping/adjacent entries of the same type
    - split all entries according to type precedence
    - rebuild the memory map from dirty map and clean map
    - align all usable entries

I have tested the algorithm quite extensively, even on absolutely insane fake
memory maps. One advantage is that regions of memory that need to be marked as a
certain type can just  added, and the  will figure it out. While I've replaced
the logic to remove the first page and the EBDA region with this, I've not yet
touched the EFI parts of the code. However, it should be a simple thing to
change. 

If you have any requests, questions or comments, I'd love to hear them.

Cheers,
yggdrasill