### PR TITLE
Add option to hide help text

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -69,6 +69,7 @@ Limine interface control options.
 * `INTERFACE_BRANDING` - A string that will be displayed on top of the Limine interface.
 * `INTERFACE_BRANDING_COLOUR` - A value between 0 and 7 specifying the colour of the branding string. Default is cyan (6).
 * `INTERFACE_BRANDING_COLOR` - Alias of `INTERFACE_BRANDING_COLOUR`.
+* `INTERFACE_HELP_HIDDEN` - Hides the help text located at the top of the screen showing the key bindings.
 
 Limine graphical terminal control options. They are ignored if using text mode.
 

--- a/common/lib/misc.c
+++ b/common/lib/misc.c
@@ -20,6 +20,7 @@ UINT32 efi_desc_ver = 0;
 #endif
 
 bool editor_enabled = true;
+bool help_hidden = false;
 
 bool parse_resolution(size_t *width, size_t *height, size_t *bpp, const char *buf) {
     size_t res[3] = {0};

--- a/common/lib/misc.h
+++ b/common/lib/misc.h
@@ -36,7 +36,7 @@ extern struct volume *boot_volume;
 extern bool stage3_loaded;
 #endif
 
-extern bool quiet, serial, editor_enabled, hash_mismatch_panic;
+extern bool quiet, serial, editor_enabled, help_hidden, hash_mismatch_panic;
 
 bool parse_resolution(size_t *width, size_t *height, size_t *bpp, const char *buf);
 

--- a/common/menu.c
+++ b/common/menu.c
@@ -692,6 +692,11 @@ noreturn void _menu(bool first_run) {
         editor_enabled = strcmp(editor_enabled_str, "yes") == 0;
     }
 
+    char *help_hidden_str = config_get_value(NULL, 0, "INTERFACE_HELP_HIDDEN");
+    if (help_hidden_str != NULL) {
+        help_hidden = strcmp(help_hidden_str, "yes") == 0;
+    }
+
     menu_branding = config_get_value(NULL, 0, "INTERFACE_BRANDING");
     if (menu_branding == NULL)
         menu_branding = "Limine " LIMINE_VERSION;
@@ -805,15 +810,17 @@ refresh:
             print(serial ? "vvv" : "↓↓↓");
         }
 
-        set_cursor_pos_helper(0, 3);
-        if (editor_enabled && selected_menu_entry->sub == NULL) {
-            print("    \e[32mARROWS\e[0m Select    \e[32mENTER\e[0m Boot    \e[32mE\e[0m Edit");
-        } else {
-            print("    \e[32mARROWS\e[0m Select    \e[32mENTER\e[0m %s",
-                  selected_menu_entry->expanded ? "Collapse" : "Expand");
+        if (!help_hidden) {
+            set_cursor_pos_helper(0, 3);
+            if (editor_enabled && selected_menu_entry->sub == NULL) {
+                print("    \e[32mARROWS\e[0m Select    \e[32mENTER\e[0m Boot    \e[32mE\e[0m Edit");
+            } else {
+                print("    \e[32mARROWS\e[0m Select    \e[32mENTER\e[0m %s",
+                      selected_menu_entry->expanded ? "Collapse" : "Expand");
+            }
+            set_cursor_pos_helper(terms[0]->cols - 13, 3);
+            print("\e[32mC\e[0m Console");
         }
-        set_cursor_pos_helper(terms[0]->cols - 13, 3);
-        print("\e[32mC\e[0m Console");
         set_cursor_pos_helper(x, y);
     }
 


### PR DESCRIPTION
I think this option would be nice for people who prefer minimalism.

![screenshot](https://github.com/limine-bootloader/limine/assets/48314599/85627281-9aa8-4180-a7da-a5d39c89115a)

(this time on the correct branch)