### PR TITLE
Multiboot2 improvements

### DIFF
--- a/common/protos/multiboot2.c
+++ b/common/protos/multiboot2.c
@@ -214,8 +214,17 @@ noreturn void multiboot2_load(char *config, char* cmdline) {
             }
 
             default:
-                if (is_required)
-                    panic(true, "multiboot2: Unknown header tag type: %u\n", tag->type);
+                if (is_required) {
+                    if (tag->type <= 10 /* max specified ID */) {
+                        panic(true, "multiboot2: Unsupported header tag type: %u\n", tag->type);
+                    } else {
+                        panic(true, "multiboot2: Unknown custom header tag type: %u\n", tag->type);
+                    }
+                } else {
+                    if (tag->type > 10) {
+                        print("multiboot2: Unknown custom header tag type: %u\n", tag->type);
+                    }
+                }
         }
     }
 

--- a/common/protos/multiboot2.c
+++ b/common/protos/multiboot2.c
@@ -206,6 +206,12 @@ noreturn void multiboot2_load(char *config, char* cmdline) {
                 reloc_tag = *reloc_tag_ptr;
                 break;
             }
+            case MULTIBOOT_HEADER_TAG_ENTRY_ADDRESS_EFI64: {
+                if (entry_point == 0xffffffff /* no alternative entry */) {
+                    panic(true, "multiboot2: required EFI AMD64 entry tag is unsupported and no alternative entry was found\n");
+                }
+                break;
+            }
 
             default:
                 if (is_required)


### PR DESCRIPTION
This improves the Multiboot2 code:

- fixes a bug to align the behavior with GRUB
- better logging of unknown Multiboot header tags

**Please** look into the commit messages for further explanation.

I didn't test it as I'm still figuring out how the test infrastructure works.