### PR TITLE
repo: init flake.nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1706569497,
+        "narHash": "sha256-oixb0IDb5eZYw6BaVr/R/1pSoMh4rfJHkVnlgeRIeZs=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "60c614008eed1d0383d21daac177a3e036192ed8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1706515015,
+        "narHash": "sha256-eFfY5A7wlYy3jD/75lx6IJRueg4noE+jowl0a8lIlVo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f4a8d6d5324c327dcc2d863eb7f3cc06ad630df4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,47 @@
+# This flake is supposed to enable a convenient development environment.
+# It is not yet devided if and how this flake exports the actually built
+# package, once this is in nixpkgs.
+# See https://github.com/limine-bootloader/limine/issues/330
+
+{
+  description = "limeboot";
+
+  inputs = {
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+  };
+
+  outputs = inputs@{ self, nixpkgs, flake-parts }:
+
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      flake = { };
+      # Don't artificially limit users at this point. If a build fails, they
+      # will notice it soon enough.
+      systems = nixpkgs.lib.systems.flakeExposed;
+      perSystem = { config, pkgs, ... }: {
+        devShells = {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              autoconf269
+              automake
+              cacert
+              gcc # TODO switch to clang for cross-build?
+              git
+              mtools
+              nasm
+              # Not in cache.nixos.org; building takes ages.
+              # But without it, `--enable-uefi-riscv64 --enable-uefi-aarch64`
+              # won't work.
+              # pkgsCross.aarch64-multiplatform.gcc
+              # This is in cache but produces an build error.
+              # pkgsCross.aarch64-multiplatform.stdenv.cc
+            ];
+          };
+          formatter = pkgs.nixpkgs-fmt;
+        };
+      };
+    };
+
+
+}


### PR DESCRIPTION
First of all: This is a proposal. I don't expect you to merge this. But I'd like to highlight the benefits and then you can decide 😄 

This inits a flake.nix. Nix users will get a shell with all relevant tools to build limine this way. The only missing bit is that `./configure --enable-uefi-riscv64 --enable-uefi-aarch64`
won't work as I didn't manage to get a proper cross-compiler in the Nix environment. I tried adding `pkgsCross.aarch64-multiplatform.gcc` to the shell but the downside is that this is not cached in cache.nixos.org; building takes ages..

I also tried switching to clang instead of gcc, but `./configure` still reported that there is no cross-toolchain.

Anyway: I think this is a improvement to the current situation.

PS: In case you are not familiar with Nix/NixOS: This here is completely orthogonal to https://github.com/limine-bootloader/limine/issues/330. It is just about developer experience in this repo.