### PR TITLE
nix: init flake.nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@
 /common-uefi-riscv64
 /decompressor-build
 /stage1.stamp
+
+# Nix
+/.direnv
+/result*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709336216,
+        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1710695816,
+        "narHash": "sha256-3Eh7fhEID17pv9ZxrPwCLfqXnYP006RKzSs0JptsN84=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "614b4613980a522ba49f0d194531beddbb7220d3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+# This flake is supposed to enable a convenient development environment.
+# It is independent of any packaging in nixpkgs.
+#
+# See https://github.com/limine-bootloader/limine/issues/330 for more details
+# regarding the packaging in nixpkgs.
+
+{
+  description = "limeboot";
+
+  inputs = {
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+  };
+
+  outputs = inputs@{ self, nixpkgs, flake-parts }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      flake = { };
+      # Don't artificially limit users at this point. If a build fails, they
+      # will notice it soon enough.
+      systems = nixpkgs.lib.systems.flakeExposed;
+      perSystem = { config, pkgs, ... }:
+        {
+          devShells = {
+            default = pkgs.mkShell {
+              packages = with pkgs; [
+                # Dependencies for ./bootstrap
+                autoconf
+                automake
+
+                # General build dependencies
+                cacert
+                git
+                mtools
+                nasm
+                pkg-config # Checked for by ./configure but seems unused?
+
+                # gcc toolchain (comes as default, here only for completness)
+                binutils
+                gcc
+
+                # llvm toolchain (with TOOLCHAIN_FOR_TARGET=llvm)
+                llvmPackages.bintools
+                llvmPackages.clang
+                llvmPackages.lld
+
+                # Nix
+                nixpkgs-fmt
+              ];
+            };
+          };
+
+          # `$ nix fmt`
+          formatter = pkgs.nixpkgs-fmt;
+        };
+    };
+}


### PR DESCRIPTION
**TL;DR**: This boosts the productivity of all people using NixOS or Nix in general in their environment. It provides you with the right environment to build this project.

This inits a flake.nix into the repository that exports a convenient Nix shell. When using `$ nix develop`, users will get a shell with all relevant tools to build the repository. If one uses a "direnv" integration into their shell, the environment is automatically loaded.

Not directly #330 but related to it.