### PR TITLE
style: init .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+max_line_length = 80
+
+[{Makefile,GNUmakefile*}]
+indent_style = tab
+
+[{*.nix,*.yml}]
+indent_size = 2


### PR DESCRIPTION
This adds an [`.editorconfig`](https://editorconfig.org/) file. 

In case you are not familiar with editorconfig: almost every IDE but also small terminal
editors support it (via plugins). It helps to set the right styling information as you type.

This is especially useful to have tabs in Makefiles but spaces otherwise.