### PR TITLE
Changing unsupported protocol panic message

### DIFF
--- a/common/menu.c
+++ b/common/menu.c
@@ -1115,5 +1115,5 @@ noreturn void boot(char *config) {
         chainload(config, cmdline);
     }
 
-    panic(true, "Unsupported protocol specified for kernel.");
+    panic(true, "Unsupported protocol specified.");
 }


### PR DESCRIPTION
The error "Unsupported protocol specified for kernel." is printed after the code fails to find a valid or existing protocol which includes not only kernels.
On top of that, the message might make the user think the chosen protocol is not supported for the specific kernel they're trying to boot instead of being a not existent protocol.