### PR TITLE
docs: PROTOCOL.md: specify TCR_EL1.TnSZ values given paging levels

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -323,8 +323,13 @@ Higher ELs do not interfere with accesses to the generic timer and counter.
 
 The used translation granule size for both `TTBR0_EL1` and `TTBR1_EL1` is 4KiB.
 
-For base revisions &gt; 0, `TCR_EL1.T0SZ` is set to 16, and `TTBR0_EL1`
-is left undefined.
+`TCR_EL1.{T0SZ, T1SZ}` are set to 16 under 4-level paging, or 12 under 5-level
+paging. Additionally, for 5-level paging, `TCR_EL1.DS` is set to 1.
+
+`TTBR1_EL1` points to the bootloader-provided higher half page tables.
+For base revision 0, `TTBR0_EL1` points to the bootloader-provided identity
+mapping page tables, and is unspecified for all other base revisions and can
+thus be freely used by the kernel.
 
 If booted by EFI/UEFI, boot services are exited.
 


### PR DESCRIPTION
As discussed in Discord, `TnSZ` is to be further specified depending on the paging level.