### PR TITLE
build: handle the case when $STRIP is a full path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,7 +59,12 @@ fi
 AC_ARG_VAR([STRIP], [strip command])
 
 if ! test -z "$STRIP"; then
-    AC_CHECK_PROG([STRIP_USER_FOUND], [$STRIP], [yes])
+    if test -x "$STRIP"; then
+        STRIP_USER_FOUND=yes
+    else
+        AC_CHECK_PROG([STRIP_USER_FOUND], [$STRIP], [yes])
+    fi
+
     if ! test "x$STRIP_USER_FOUND" = "xyes"; then
         AC_MSG_ERROR([$STRIP not found, please install $STRIP before configuring])
     fi


### PR DESCRIPTION
Bit of a hack, but as AC_CHECK_PROG iterators each path under $PATH, trying to find $STRIP under each one, the case where $STRIP is a full path is not handled correctly. Let's use `test -x` to check for that beforehand.