### PR TITLE
protos/multiboot2: fix issues with booting relocatable multiboot2 payloads

### DIFF
--- a/common/protos/multiboot2.c
+++ b/common/protos/multiboot2.c
@@ -314,24 +314,24 @@ noreturn void multiboot2_load(char *config, char* cmdline) {
         }
     }
 
-    uint64_t reloc_slide = 0;
+    int64_t reloc_slide = 0;
 
     if (has_reloc_header) {
         bool reloc_ascend;
-        uint64_t relocated_base;
+        int64_t relocated_base;
 
         switch (reloc_tag.preference) {
             default:
             case 0: case 1: // Prefer lowest to highest
                 reloc_ascend = true;
-                relocated_base = ALIGN_UP(reloc_tag.min_addr, reloc_tag.align);
+                relocated_base = (int64_t)ALIGN_UP(reloc_tag.min_addr, reloc_tag.align);
                 if (relocated_base + ranges->length > reloc_tag.max_addr) {
                     goto reloc_fail;
                 }
                 break;
             case 2: // Prefer highest to lowest
                 reloc_ascend = false;
-                relocated_base = ALIGN_DOWN(reloc_tag.max_addr - ranges->length, reloc_tag.align);
+                relocated_base = (int64_t)ALIGN_DOWN(reloc_tag.max_addr - ranges->length, reloc_tag.align);
                 if (relocated_base < reloc_tag.min_addr) {
                     goto reloc_fail;
                 }

--- a/common/protos/multiboot2.c
+++ b/common/protos/multiboot2.c
@@ -356,8 +356,7 @@ noreturn void multiboot2_load(char *config, char* cmdline) {
             }
         }
 
-        reloc_slide = reloc_ascend ?
-            relocated_base - ranges->target : ranges->target - relocated_base;
+        reloc_slide = relocated_base - ranges->target;
 
         entry_point += reloc_slide;
 

--- a/common/protos/multiboot2.c
+++ b/common/protos/multiboot2.c
@@ -318,20 +318,20 @@ noreturn void multiboot2_load(char *config, char* cmdline) {
 
     if (has_reloc_header) {
         bool reloc_ascend;
-        int64_t relocated_base;
+        uint64_t relocated_base;
 
         switch (reloc_tag.preference) {
             default:
             case 0: case 1: // Prefer lowest to highest
                 reloc_ascend = true;
-                relocated_base = (int64_t)ALIGN_UP(reloc_tag.min_addr, reloc_tag.align);
+                relocated_base = ALIGN_UP(reloc_tag.min_addr, reloc_tag.align);
                 if (relocated_base + ranges->length > reloc_tag.max_addr) {
                     goto reloc_fail;
                 }
                 break;
             case 2: // Prefer highest to lowest
                 reloc_ascend = false;
-                relocated_base = (int64_t)ALIGN_DOWN(reloc_tag.max_addr - ranges->length, reloc_tag.align);
+                relocated_base = ALIGN_DOWN(reloc_tag.max_addr - ranges->length, reloc_tag.align);
                 if (relocated_base < reloc_tag.min_addr) {
                     goto reloc_fail;
                 }
@@ -356,7 +356,7 @@ noreturn void multiboot2_load(char *config, char* cmdline) {
             }
         }
 
-        reloc_slide = relocated_base - ranges->target;
+        reloc_slide = (int64_t)relocated_base - ranges->target;
 
         entry_point += reloc_slide;
 

--- a/common/protos/multiboot2.c
+++ b/common/protos/multiboot2.c
@@ -324,14 +324,14 @@ noreturn void multiboot2_load(char *config, char* cmdline) {
             default:
             case 0: case 1: // Prefer lowest to highest
                 reloc_ascend = true;
-                relocated_base = ALIGN_UP(reloc_tag.align, reloc_tag.min_addr);
+                relocated_base = ALIGN_UP(reloc_tag.min_addr, reloc_tag.align);
                 if (relocated_base + ranges->length > reloc_tag.max_addr) {
                     goto reloc_fail;
                 }
                 break;
             case 2: // Prefer highest to lowest
                 reloc_ascend = false;
-                relocated_base = ALIGN_DOWN(reloc_tag.align, reloc_tag.max_addr - ranges->length);
+                relocated_base = ALIGN_DOWN(reloc_tag.max_addr - ranges->length, reloc_tag.align);
                 if (relocated_base < reloc_tag.min_addr) {
                     goto reloc_fail;
                 }


### PR DESCRIPTION
This PR fixes two issues that caused booting relocatable multiboot2 payloads to fail:
1. The order of the parameters to the ALIGN_* macros was incorrect (so alignment was aligned to min/max addr instead of the other way around). This caused incorrect alignment, or a division exception if lowest-to-highest allocation is preferred and the minimum address is zero.
2. `reloc_slide` was calculated as the absolute offset between the declared base address and the actual base address, but used as if it weren't absolute. This caused the relocated entry point address to be calculated incorrectly if highest-to-lowest allocation is preferred.