### PR TITLE
protos/limine: increase MEMMAP_MAX

### DIFF
--- a/common/protos/limine.c
+++ b/common/protos/limine.c
@@ -34,7 +34,7 @@
 
 #define MAX_REQUESTS 128
 
-#define MEMMAP_MAX 256
+#define MEMMAP_MAX 512
 
 static int paging_mode;
 

--- a/common/protos/limine.c
+++ b/common/protos/limine.c
@@ -34,7 +34,7 @@
 
 #define MAX_REQUESTS 128
 
-#define MEMMAP_MAX 512
+#define MEMMAP_MAX 1024
 
 static int paging_mode;
 


### PR DESCRIPTION
On some systems, the memory map exceeds 256 entries (on my system, it has 312 entries). That causes the bootloader to panic when booting Limine payloads. This PR simply doubles the limit.