### PR TITLE
protos/limine: Add device tree blob override config option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 *.hdd
 *.iso
 *.sys
+*.dtb
 *~
 
 /bin

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -132,6 +132,7 @@ Editor control options:
     - riscv64: `sv39`, `sv48`, `sv57`.
     - loongarch64: `4level`.
   * `paging_mode` - Equivalent to setting both `max_paging_mode` and `min_paging_mode` to the same value.
+  * `dtb_path` - A device tree blob to pass instead of the one provided by the firmware.
 
 * multiboot1 and multiboot2 protocols:
   * `kernel_path` - The path of the kernel.

--- a/common/menu.c
+++ b/common/menu.c
@@ -117,6 +117,7 @@ static const char *VALID_KEYS[] = {
     "GPT_GUID",
     "GPT_UUID",
     "IMAGE_PATH",
+	"DTB_PATH",
     NULL
 };
 

--- a/common/protos/limine.c
+++ b/common/protos/limine.c
@@ -1006,12 +1006,7 @@ FEAT_START
         if ((dtb_file = uri_open(dtb_path)) == NULL)
             panic(true, "limine: Failed to open device tree blob with path `%#`. Is the path correct?", dtb_path);
 
-        dtb = freadall_mode(dtb_file, MEMMAP_BOOTLOADER_RECLAIMABLE, false
-#if defined (__i386__)
-        , limine_memcpy_to_64
-#endif
-        );
-
+        dtb = freadall(dtb_file, MEMMAP_BOOTLOADER_RECLAIMABLE);
         fclose(dtb_file);
     } else {
 #if defined (UEFI)

--- a/common/protos/limine.c
+++ b/common/protos/limine.c
@@ -998,8 +998,22 @@ FEAT_START
         break; // next feature
     }
 
+    void *dtb = NULL;
+    char *dtb_path = config_get_value(config, 0, "DTB_PATH");
+
+    if (dtb_path) {
+        struct file_handle *dtb_file;
+        if ((dtb_file = uri_open(dtb_path)) == NULL)
+            panic(true, "limine: Failed to open device tree blob with path `%#`. Is the path correct?", kernel_path);
+        dtb = freadall_mode(dtb_file, MEMMAP_BOOTLOADER_RECLAIMABLE, false);
+        fclose(dtb_file);
+    } else {
 #if defined (UEFI)
-    void *dtb = get_device_tree_blob(0);
+        dtb = get_device_tree_blob(0);
+#else
+        break;
+#endif
+    }
 
     if (dtb) {
         struct limine_dtb_response *dtb_response =
@@ -1007,7 +1021,6 @@ FEAT_START
         dtb_response->dtb_ptr = reported_addr(dtb);
         dtb_request->response = reported_addr(dtb_response);
     }
-#endif
 
 FEAT_END
 

--- a/common/protos/limine.c
+++ b/common/protos/limine.c
@@ -1004,7 +1004,7 @@ FEAT_START
     if (dtb_path) {
         struct file_handle *dtb_file;
         if ((dtb_file = uri_open(dtb_path)) == NULL)
-            panic(true, "limine: Failed to open device tree blob with path `%#`. Is the path correct?", kernel_path);
+            panic(true, "limine: Failed to open device tree blob with path `%#`. Is the path correct?", dtb_path);
 
         dtb = freadall_mode(dtb_file, MEMMAP_BOOTLOADER_RECLAIMABLE, false
 #if defined (__i386__)

--- a/common/protos/limine.c
+++ b/common/protos/limine.c
@@ -1005,7 +1005,13 @@ FEAT_START
         struct file_handle *dtb_file;
         if ((dtb_file = uri_open(dtb_path)) == NULL)
             panic(true, "limine: Failed to open device tree blob with path `%#`. Is the path correct?", kernel_path);
-        dtb = freadall_mode(dtb_file, MEMMAP_BOOTLOADER_RECLAIMABLE, false);
+
+        dtb = freadall_mode(dtb_file, MEMMAP_BOOTLOADER_RECLAIMABLE, false
+#if defined (__i386__)
+        , limine_memcpy_to_64
+#endif
+        );
+
         fclose(dtb_file);
     } else {
 #if defined (UEFI)

--- a/test/device_tree.dts
+++ b/test/device_tree.dts
@@ -1,0 +1,12 @@
+// Example device tree.
+
+/dts-v1/;
+
+/ {
+    soc {
+        limine_node: limine-node@deadbeef {
+            reg = <0xdeadbeef 0x1000>;
+            label = "KANKER";
+        };
+    };
+};

--- a/test/limine.c
+++ b/test/limine.c
@@ -518,6 +518,8 @@ FEAT_START
     struct limine_dtb_response *dtb_response = _dtb_request.response;
     e9_printf("Device tree blob feature, revision %d", dtb_response->revision);
     e9_printf("Device tree blob pointer: %x", dtb_response->dtb_ptr);
+	uint32_t dtb_magic = *(uint32_t*)dtb_response->dtb_ptr;
+	e9_printf("Device tree header magic: %x", dtb_magic);
 FEAT_END
 
 FEAT_START

--- a/test/limine.conf
+++ b/test/limine.conf
@@ -20,6 +20,7 @@ backdrop: 008080
     module_cmdline: This is the first module.
 
     module_path: boot():/boot/bg.jpg
+    dtb_path: boot():/boot/device_tree.dtb
 
 /Multiboot2 Test
     comment: Test of the multiboot2 boot protocol.

--- a/test/test.mk
+++ b/test/test.mk
@@ -108,9 +108,9 @@ override CFLAGS_MB := \
     -I../common/protos
 
 ifneq ($(findstring 86,$(shell $(CC_FOR_TARGET) -dumpmachine)),)
-all: test.elf multiboot2.elf multiboot.elf
+all: test.elf multiboot2.elf multiboot.elf device_tree.dtb
 else
-all: test.elf
+all: test.elf device_tree.dtb
 endif
 
 flanterm:
@@ -141,8 +141,11 @@ multiboot.elf: multiboot_trampoline.o
 %.o: %.asm
 	nasm -felf32 -F dwarf -g $< -o $@
 
+%.dtb: %.dts
+	dtc $< -o $@
+
 clean:
 	rm -rf test.elf limine.o e9print.o memory.o
 	rm -rf multiboot2.o multiboot2.elf multiboot2_trampoline.o
 	rm -rf multiboot.o multiboot_trampoline.o multiboot.elf
-	rm -rf flanterm limine.h
+	rm -rf flanterm limine.h device_tree.dtb


### PR DESCRIPTION
This PR adds the `dtb_path` option to the Limine protocol.
It allows the user to specify a file to pass to the `DTB_REQUEST` instead of the address passed by the firmware.
