### PR TITLE
protos/linux: Add device tree blob override config option

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -118,6 +118,7 @@ Editor control options:
   * `module_path` - The path to a module (such as initramfs). This option can be specified multiple times to specify multiple modules.
   * `resolution` - The resolution to be used. This setting takes the form of `<width>x<height>x<bpp>`. If the resolution is not available, Limine will pick another one automatically. Omitting `<bpp>` will default to 32.
   * `textmode` - If set to `yes`, prefer text mode. (BIOS only)
+  * `dtb_path` - A device tree blob to pass instead of the one provided by the firmware.
 
 * Limine protocol:
   * `kernel_path` - The path of the kernel.

--- a/common/protos/linux_risc.c
+++ b/common/protos/linux_risc.c
@@ -88,17 +88,13 @@ void *prepare_device_tree_blob(char *config, char *cmdline) {
     if (dtb_path) {
         struct file_handle *dtb_file;
         if ((dtb_file = uri_open(dtb_path)) == NULL)
-            panic(true, "limine: Failed to open device tree blob with path `%#`. Is the path correct?", dtb_path);
+            panic(true, "linux: Failed to open device tree blob with path `%#`. Is the path correct?", dtb_path);
 
         dtb = freadall(dtb_file, MEMMAP_BOOTLOADER_RECLAIMABLE);
         fclose(dtb_file);
     } else {
-#if defined (UEFI)
     	// Hopefully 4K should be enough (mainly depends on the length of cmdline).
     	dtb = get_device_tree_blob(0x1000);
-#else
-        break;
-#endif
     }
 
     int ret;

--- a/common/protos/linux_risc.c
+++ b/common/protos/linux_risc.c
@@ -82,8 +82,25 @@ void add_framebuffer(struct fb_info *fb) {
 }
 
 void *prepare_device_tree_blob(char *config, char *cmdline) {
-    // Hopefully 4K should be enough (mainly depends on the length of cmdline).
-    void *dtb = get_device_tree_blob(0x1000);
+    void *dtb = NULL;
+    char *dtb_path = config_get_value(config, 0, "DTB_PATH");
+
+    if (dtb_path) {
+        struct file_handle *dtb_file;
+        if ((dtb_file = uri_open(dtb_path)) == NULL)
+            panic(true, "limine: Failed to open device tree blob with path `%#`. Is the path correct?", dtb_path);
+
+        dtb = freadall(dtb_file, MEMMAP_BOOTLOADER_RECLAIMABLE);
+        fclose(dtb_file);
+    } else {
+#if defined (UEFI)
+    	// Hopefully 4K should be enough (mainly depends on the length of cmdline).
+    	dtb = get_device_tree_blob(0x1000);
+#else
+        break;
+#endif
+    }
+
     int ret;
 
     // Delete all /memory@... nodes. Linux will use the given UEFI memory map


### PR DESCRIPTION
This PR does the same as #419 for the `linux` protocol.