### PR TITLE
protos/limine: Filter `memory@...` nodes from device trees

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1289,3 +1289,6 @@ Note: If the DTB cannot be found, the response will *not* be generated.
 
 Note: Information contained in the `/chosen` node may not reflect the information
 given by bootloader tags, and as such the `/chosen` node properties should be ignored.
+
+Note: If the DTB contained `memory@...` nodes, they will get removed.
+Kernels may not rely on these nodes and should use the Memory Map feature instead.

--- a/test.mk
+++ b/test.mk
@@ -36,8 +36,8 @@ ovmf-loongarch64:
 test.hdd:
 	rm -f test.hdd
 	dd if=/dev/zero bs=1M count=0 seek=64 of=test.hdd
-	sudo parted -s test.hdd mklabel gpt
-	sudo parted -s test.hdd mkpart primary 2048s 100%
+	parted -s test.hdd mklabel gpt
+	parted -s test.hdd mkpart primary 2048s 100%
 
 .PHONY: mbrtest.hdd
 mbrtest.hdd:

--- a/test.mk
+++ b/test.mk
@@ -36,8 +36,8 @@ ovmf-loongarch64:
 test.hdd:
 	rm -f test.hdd
 	dd if=/dev/zero bs=1M count=0 seek=64 of=test.hdd
-	parted -s test.hdd mklabel gpt
-	parted -s test.hdd mkpart primary 2048s 100%
+	sudo parted -s test.hdd mklabel gpt
+	sudo parted -s test.hdd mkpart primary 2048s 100%
 
 .PHONY: mbrtest.hdd
 mbrtest.hdd:

--- a/test/device_tree.dts
+++ b/test/device_tree.dts
@@ -4,9 +4,13 @@
 
 / {
     soc {
-        limine_node: limine-node@deadbeef {
+        limine_node: limine@deadbeef {
             reg = <0xdeadbeef 0x1000>;
             label = "KANKER";
+        };
+        fake_memory: memory@ffff0000 {
+            reg = <0xffff0000 0xffff>;
+            label = "This node will be removed by Limine.";
         };
     };
 };


### PR DESCRIPTION
This PR makes sure that implementing kernels can't use the potentially inaccurate `memory` nodes in a device tree passed by the DTB response.