### PR TITLE
protos/limine: Add RISC-V BSP Hart ID request

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -880,6 +880,34 @@ processor. This field is unused for the structure describing the bootstrap
 processor.
 * `extra_argument` - A free for use field.
 
+### RISC-V BSP Hart ID Feature
+
+ID:
+```c
+#define LIMINE_RISCV_BSP_HARTID_REQUEST { LIMINE_COMMON_MAGIC, 0x1369359f025525f9, 0x2ff2a56178391bb6 }
+```
+
+Request:
+```c
+struct limine_riscv_bsp_hartid_request {
+    uint64_t id[4];
+    uint64_t revision;
+    LIMINE_PTR(struct limine_riscv_bsp_hartid_response *) response;
+};
+```
+
+Response:
+```c
+struct limine_riscv_bsp_hartid_response {
+    uint64_t revision;
+    uint64_t bsp_hartid;
+};
+```
+
+* `bsp_hartid` - The Hart ID of the boot processor.
+Note: This request contains the same information as `limine_mp_response.bsp_hartid`,
+but doesn't boot up other APs.
+
 ### Memory Map Feature
 
 ID:

--- a/common/protos/limine.c
+++ b/common/protos/limine.c
@@ -1475,6 +1475,19 @@ FEAT_START
     mp_request->response = reported_addr(mp_response);
 FEAT_END
 
+#if defined(__riscv)
+    // RISC-V BSP Hart ID
+FEAT_START
+    struct limine_riscv_bsp_hartid_request *bsp_request = get_request(LIMINE_RISCV_BSP_HARTID_REQUEST);
+    if (bsp_request == NULL) {
+        break;
+    }
+    struct limine_riscv_bsp_hartid_response *bsp_response = ext_mem_alloc(sizeof(struct limine_riscv_bsp_hartid_response));
+    bsp_response->bsp_hartid = bsp_hartid;
+    bsp_request->response = reported_addr(bsp_response);
+FEAT_END
+#endif
+
     // Memmap
 FEAT_START
     struct limine_memmap_request *memmap_request = get_request(LIMINE_MEMMAP_REQUEST);

--- a/limine.h
+++ b/limine.h
@@ -648,6 +648,21 @@ struct limine_dtb_request {
     LIMINE_PTR(struct limine_dtb_response *) response;
 };
 
+/* RISC-V Boot Hart ID */
+
+#define LIMINE_RISCV_BSP_HARTID_REQUEST { LIMINE_COMMON_MAGIC, 0x1369359f025525f9, 0x2ff2a56178391bb6 }
+
+struct limine_riscv_bsp_hartid_response {
+    uint64_t revision;
+    uint64_t bsp_hartid;
+};
+
+struct limine_riscv_bsp_hartid_request {
+    uint64_t id[4];
+    uint64_t revision;
+    LIMINE_PTR(struct limine_riscv_bsp_hartid_response *) response;
+};
+
 #ifdef __cplusplus
 }
 #endif

--- a/test.mk
+++ b/test.mk
@@ -36,8 +36,8 @@ ovmf-loongarch64:
 test.hdd:
 	rm -f test.hdd
 	dd if=/dev/zero bs=1M count=0 seek=64 of=test.hdd
-	parted -s test.hdd mklabel gpt
-	parted -s test.hdd mkpart primary 2048s 100%
+	PATH=$PATH:/sbin:/usr/sbin parted -s test.hdd mklabel gpt
+	PATH=$PATH:/sbin:/usr/sbin parted -s test.hdd mkpart primary 2048s 100%
 
 .PHONY: mbrtest.hdd
 mbrtest.hdd:

--- a/test/limine.c
+++ b/test/limine.c
@@ -152,6 +152,14 @@ static volatile struct limine_paging_mode_request _pm_request = {
     .min_mode = LIMINE_PAGING_MODE_MIN
 };
 
+#ifdef __riscv
+__attribute__((section(".limine_requests")))
+static volatile struct limine_riscv_bsp_hartid_request _bsp_request = {
+    .id = LIMINE_RISCV_BSP_HARTID_REQUEST,
+    .revision = 0, .response = NULL,
+};
+#endif
+
 __attribute__((used, section(".limine_requests_end_marker")))
 static volatile LIMINE_REQUESTS_END_MARKER;
 
@@ -537,6 +545,16 @@ FEAT_START
     struct limine_paging_mode_response *pm_response = _pm_request.response;
     e9_printf("Paging mode feature, revision %d", pm_response->revision);
     e9_printf("  mode: %d", pm_response->mode);
+FEAT_END
+
+FEAT_START
+    e9_printf("");
+    struct limine_riscv_bsp_hartid_response *bsp_response = _bsp_request.response;
+    if (bsp_response == NULL) {
+        e9_printf("RISC-V BSP Hart ID was not passed");
+        break;
+    }
+    e9_printf("RISC-V BSP Hart ID: %x", bsp_response->bsp_hartid);
 FEAT_END
 
     for (;;);


### PR DESCRIPTION
This PR adds a request to the Limine protocol to query the BSP Hart ID like the MP request, but without necessarily booting up other APs.