### PR TITLE
protos/linux_risc: add LoongArch support

### DIFF
--- a/common/lib/misc.c
+++ b/common/lib/misc.c
@@ -16,7 +16,7 @@ EFI_BOOT_SERVICES *gBS;
 EFI_RUNTIME_SERVICES *gRT;
 EFI_HANDLE efi_image_handle;
 EFI_MEMORY_DESCRIPTOR *efi_mmap = NULL;
-UINTN efi_mmap_size = 0, efi_desc_size = 0;
+UINTN efi_mmap_size = 0, efi_desc_size = 0, efi_mmap_key = 0;
 UINT32 efi_desc_ver = 0;
 #endif
 
@@ -205,9 +205,8 @@ bool efi_exit_boot_services(void) {
 
     EFI_MEMORY_DESCRIPTOR tmp_mmap[1];
     efi_mmap_size = sizeof(tmp_mmap);
-    UINTN mmap_key = 0;
 
-    gBS->GetMemoryMap(&efi_mmap_size, tmp_mmap, &mmap_key, &efi_desc_size, &efi_desc_ver);
+    gBS->GetMemoryMap(&efi_mmap_size, tmp_mmap, &efi_mmap_key, &efi_desc_size, &efi_desc_ver);
 
     efi_mmap_size += 4096;
 
@@ -232,13 +231,13 @@ bool efi_exit_boot_services(void) {
     size_t retries = 0;
 
 retry:
-    status = gBS->GetMemoryMap(&efi_mmap_size, efi_mmap, &mmap_key, &efi_desc_size, &efi_desc_ver);
+    status = gBS->GetMemoryMap(&efi_mmap_size, efi_mmap, &efi_mmap_key, &efi_desc_size, &efi_desc_ver);
     if (retries == 0 && status) {
         goto fail;
     }
 
     // Be gone, UEFI!
-    status = gBS->ExitBootServices(efi_image_handle, mmap_key);
+    status = gBS->ExitBootServices(efi_image_handle, efi_mmap_key);
     if (status) {
         if (retries == 128) {
             goto fail;

--- a/common/lib/misc.h
+++ b/common/lib/misc.h
@@ -21,7 +21,7 @@ extern EFI_BOOT_SERVICES *gBS;
 extern EFI_RUNTIME_SERVICES *gRT;
 extern EFI_HANDLE efi_image_handle;
 extern EFI_MEMORY_DESCRIPTOR *efi_mmap;
-extern UINTN efi_mmap_size, efi_desc_size;
+extern UINTN efi_mmap_size, efi_desc_size, efi_mmap_key;
 extern UINT32 efi_desc_ver;
 
 extern bool efi_boot_services_exited;

--- a/common/menu.c
+++ b/common/menu.c
@@ -1190,12 +1190,7 @@ noreturn void boot(char *config) {
     if (!strcmp(proto, "limine")) {
         limine_load(config, cmdline);
     } else if (!strcmp(proto, "linux")) {
-#if defined (__loongarch64)
-        quiet = false;
-        print("TODO: Linux is not available on LoongArch64.\n\n");
-#else
         linux_load(config, cmdline);
-#endif
     } else if (!strcmp(proto, "multiboot1") || !strcmp(proto, "multiboot")) {
 #if defined (__x86_64__) || defined (__i386__)
         multiboot1_load(config, cmdline);


### PR DESCRIPTION
This series cleans up linux_risc.c, implements EFI-table-based boot param passing and finally supports Linux boot protocol on LoongArch.

Has been tested with EDK2 firmware on qemu-emulated loongarch64 and riscv64, everything works. I'll verify on loongarch64/aarch64 real hardware when I'm available.

Thanks for your time and review.