### PR TITLE
Update PROTOCOL.md: make module request more explicit

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1091,6 +1091,8 @@ struct limine_module_response {
 };
 ```
 
+Note: `limine_module_response` is not guaranteed when no modules are passed in.
+
 * `module_count` - How many modules are present.
 * `modules` - Pointer to an array of `module_count` pointers to
 `struct limine_file` structures (see below).


### PR DESCRIPTION
make it explicit that when no modules are passed into limine, a response is not guaranteed.

I believe this is important for when someone is ctrl+f to find a certain request.

Yes limine makes it known that responses are not guaranteed but its vague about this in relation to which requests will it not provide a response to in certain situations.