### PR TITLE
bootstrap: fix posix compliance

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -37,9 +37,9 @@ clone_repo_commit() {
 
 download_by_hash() {
     DOWNLOAD_COMMAND="curl -Lo"
-    if ! command -v $DOWNLOAD_COMMAND >/dev/null 2>&1; then
+    if ! command -v "${DOWNLOAD_COMMAND% *}" >/dev/null 2>&1; then
         DOWNLOAD_COMMAND="wget -O"
-        if ! command -v $DOWNLOAD_COMMAND >/dev/null 2>&1; then
+        if ! command -v "${DOWNLOAD_COMMAND% *}" >/dev/null 2>&1; then
             set +x
             echo "error: Neither curl nor wget found"
             exit 1


### PR DESCRIPTION
The "command" builtin takes an executable name, not a full command line with arguments, which on some shells will result in nothing being matched.