### PR TITLE
libc: add a strcat implementation

### DIFF
--- a/common/lib/libc.s2.c
+++ b/common/lib/libc.s2.c
@@ -60,6 +60,18 @@ char *strncpy(char *dest, const char *src, size_t n) {
     return dest;
 }
 
+char *strcat(char *dest, const char *src) {
+    size_t len;
+    size_t i;
+
+    for (len = strlen(dest), i = 0; src[i]; i++)
+        dest[len + i] = src[i];
+
+    dest[len + i] = 0;
+
+    return dest;
+}
+
 int strcmp(const char *s1, const char *s2) {
     for (size_t i = 0; ; i++) {
         char c1 = s1[i], c2 = s2[i];

--- a/common/libc-compat/string.h
+++ b/common/libc-compat/string.h
@@ -11,6 +11,7 @@ void *memchr(const void *, int, size_t);
 
 char *strcpy(char *, const char *);
 char *strncpy(char *, const char *, size_t);
+char *strcat(char *, const char *);
 char *strchr(const char *, int);
 char *strrchr(const char *, int);
 size_t strlen(const char *);


### PR DESCRIPTION
I was working on a new PR but found there was no strcat for string building. This will resolve that.