### PR TITLE
docs: Add branding colour documentation

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -119,7 +119,17 @@ Limine interface control options:
 * `interface_branding` - A string that will be displayed on top of the Limine
   interface.
 * `interface_branding_colour` - A value between 0 and 7 specifying the colour
-  of the branding string. Default is cyan (6).
+  of the branding string.
+  | Code | Color          |
+  |------|----------------|
+  | 0    | Black          |
+  | 1    | Red            |
+  | 2    | Green          |
+  | 3    | Yellow         |
+  | 4    | Blue           |
+  | 5    | Magenta        |
+  | 6    | Cyan (Default) |
+  | 7    | White          |
 * `interface_branding_color` - Alias of `interface_branding_colour`.
 * `interface_help_hidden` - Hides the help text located at the top of the
   screen showing the key bindings.


### PR DESCRIPTION
Simple table for the color codes, to me it was not intuitively clear that those are ANSI colors.