### PR TITLE
reimplement stage1 changes

### DIFF
--- a/stage1/hdd/bootsect.asm
+++ b/stage1/hdd/bootsect.asm
@@ -78,6 +78,10 @@ start:
     lgdt [gdt]
 
     cli
+
+    push dword 0
+    mov ebp, 0x10
+
     mov eax, cr0
     bts ax, 0
     mov cr0, eax
@@ -114,16 +118,13 @@ err:
 
 bits 32
 vector:
-    mov eax, 0x10
-    mov ds, ax
-    mov es, ax
-    mov fs, ax
-    mov gs, ax
-    mov ss, ax
+    mov ds, ebp
+    mov es, ebp
+    mov fs, ebp
+    mov gs, ebp
+    mov ss, ebp
 
     and edx, 0xff
-
-    push 0
 
     push edx
 

--- a/stage1/hdd/disk.asm
+++ b/stage1/hdd/disk.asm
@@ -35,14 +35,13 @@ read_sectors:
     mov word [si], 30       ; buf_size
     int 0x13
     jc .done
-    mov bp, word [si+24]    ; bytes_per_sect
+    movzx ebp, word [si+24] ; bytes_per_sect
 
     ; ECX byte count to CX sector count
-    mov ax, cx
-    shr ecx, 16
-    mov dx, cx
+    mov eax, ecx
+    xor edx, edx
+    div ebp
     xor cx, cx
-    div bp
     test dx, dx
     setnz cl
     add cx, ax
@@ -52,10 +51,15 @@ read_sectors:
 
     pop si
 
-    ; EBP:EAX address to EAX LBA sector
+    ; EBP:EAX address to DAP LBA sector
+    push eax
+    mov eax, edx            ; divide high dword first
+    xor edx, edx
     div ebp
-    mov dword [si+8],  eax
-    mov dword [si+12], 0
+    mov dword [si+12], eax
+    pop eax
+    div ebp                 ; divide low dword next along with remainder of high dword
+    mov dword [si+8], eax
 
     pop dx
 
@@ -67,10 +71,8 @@ read_sectors:
     jc .done
 
     add word  [si+4], bp
-    xor ebx, ebx
-    inc dword [si+8]
-    seto bl
-    add dword [si+12], ebx
+    add dword [si+8], 1
+    adc dword [si+12], 0
 
     loop .loop
 

--- a/stage1/hdd/disk.asm
+++ b/stage1/hdd/disk.asm
@@ -34,7 +34,7 @@ read_sectors:
     mov si, .drive_params
     mov word [si], 30       ; buf_size
     int 0x13
-    jc .done
+    pushf
     movzx ebp, word [si+24] ; bytes_per_sect
 
     ; ECX byte count to CX sector count
@@ -46,10 +46,12 @@ read_sectors:
     setnz cl
     add cx, ax
 
+    popf
     pop edx
     pop eax
 
     pop si
+    jc .done
 
     ; EBP:EAX address to DAP LBA sector
     push eax


### PR DESCRIPTION
This PR reimplements three bugfixes in the stage1 disk_read routine:
* bytes per sector is stored in bp, but ebp is sometimes used instead, so the upper word should be set to zero
* correctly handle 64-bit logical block addresses
* fix stack imbalance if int 13h fails

I also cherry-picked a commit by Mint that they told me was written by hand, which rearranges some bytes so that the boot sector size limitations are still respected.