### PR TITLE
align the boot menu closer to systemd-boot's.

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -76,7 +76,10 @@ Miscellaneous:
 
 * `timeout` - Specifies the timeout in seconds before the first *entry* is
   automatically booted. If set to `no`, disable automatic boot. If set to `0`,
-  boots default entry instantly (see `default_entry` option).
+  boot the default entry (see `default_entry` option) after a brief (~1 second)
+  window during which pressing any key reveals the menu. This window matches
+  the systemd-boot behaviour of allowing the user to hold a key (space is a
+  good choice) to bring up the menu at zero timeout.
 * `quiet` - If set to `yes`, enable quiet mode, where all screen output except
   panics and important warnings is suppressed. If `timeout` is not 0, the
   `timeout` still occurs, and pressing any key during the timeout will reveal

--- a/common/menu.c
+++ b/common/menu.c
@@ -1326,8 +1326,13 @@ noreturn void _menu(bool first_run) {
             quiet = false;
             print("Default entry is not valid or directory, booting to menu.\n");
             skip_timeout = true;
-        } else {
+        } else if (pit_sleep_and_quit_on_keypress(1) == 0) {
             goto autoboot;
+        } else {
+            /*  systemd-boot-esque: key pressed in the brief boot window; reveal the
+                menu instead of booting the default entry.  */
+            skip_timeout = true;
+            quiet = false;
         }
     }
 
@@ -1581,7 +1586,6 @@ timeout_aborted:
                 goto refresh;
             case GETCHAR_CURSOR_RIGHT:
             case '\n':
-            case ' ':
             autoboot:
                 if (max_entries == 0) {
                     break;
@@ -1656,6 +1660,37 @@ timeout_aborted:
                     }
                     booting_from_blank = false;
                     goto refresh;
+                }
+                break;
+            }
+            default: {
+                /*  Cycle the selection to the next visible entry whose name starts
+                    with the pressed letter  */
+                if (max_entries == 0)
+                    break;
+                if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')))
+                    break;
+                char target = (char)c;
+                if (target >= 'A' && target <= 'Z') {
+                    target = (char)(target - 'A' + 'a');
+                }
+                for (size_t step = 1; step <= max_entries; step++) {
+                    size_t idx = (selected_entry + step) % max_entries;
+                    struct menu_entry * candidate = NULL;
+                    print_tree(0, 0, NULL, 0, 0, idx, menu_tree,
+                               &candidate, NULL, NULL);
+                    if (candidate == NULL || candidate->name == NULL
+                     || candidate->name[0] == 0) {
+                        continue;
+                    }
+                    char first = candidate->name[0];
+                    if (first >= 'A' && first <= 'Z') {
+                        first = (char)(first - 'A' + 'a');
+                    }
+                    if (first == target) {
+                        selected_entry = idx;
+                        goto refresh;
+                    }
                 }
                 break;
             }


### PR DESCRIPTION
1) space no longer boots the selected entry.
2) there is now a brief delay that allows the user to bring up the boot menu via (i.a.) space. 3) a-zA-Z not bound to existing commands now allow cycling through entries whose names start with the pressed letter.

resolves #554