### PR TITLE
efi: add protocol: efi_handover for firmware-native chainloading

### DIFF
--- a/common/menu.c
+++ b/common/menu.c
@@ -770,7 +770,8 @@ static inline bool should_skip_entry(struct menu_entry *entry) {
         if (strcmp(cur_entry_protocol, "efi") == 0
          || strcmp(cur_entry_protocol, "uefi") == 0
          || strcmp(cur_entry_protocol, "efi_chainload") == 0
-         || strcmp(cur_entry_protocol, "efi_boot_entry") == 0) {
+         || strcmp(cur_entry_protocol, "efi_boot_entry") == 0
+         || strcmp(cur_entry_protocol, "efi_handover") == 0)	 {
 #endif
             return true;
         }
@@ -2072,6 +2073,9 @@ noreturn void boot(char *config) {
 #if defined (UEFI)
     else if (!strcmp(proto, "efi_boot_entry")) {
         efi_boot_entry(config);
+    }
+    else if (!strcmp(proto, "efi_handover")) {
+	    chainload_handover(config, cmdline);
     }
 #endif
 

--- a/common/protos/chainload.c
+++ b/common/protos/chainload.c
@@ -256,6 +256,99 @@ static EFI_DEVICE_PATH_PROTOCOL *build_relative_efi_file_path(struct file_handle
     return device_path;
 }
 
+
+noreturn void chainload_handover(char *config, char *cmdline) {
+    // 1. Retrieve the target image path from config
+    char *image_path = config_get_value(config, 0, "PATH");
+    if (image_path == NULL) {
+        image_path = config_get_value(config, 0, "IMAGE_PATH");
+    }
+
+    if (image_path == NULL) {
+        panic(true, "efi-handover: Image path not specified");
+    }
+
+    // Disable Limine's SB checks; LoadImage does its own hardware verification.
+    bool saved_secure_boot_active = secure_boot_active;
+    secure_boot_active = false;
+
+    struct file_handle *image;
+#if defined (__i386__)
+    image = uri_open(image_path, MEMMAP_RESERVED, false, NULL, NULL);
+#else
+    image = uri_open(image_path, MEMMAP_RESERVED, false);
+#endif
+
+    if (image == NULL) {
+        panic(true, "efi-handover: Failed to open image `%s`", image_path);
+    }
+
+    secure_boot_active = saved_secure_boot_active;
+
+    // 3. Resolve native UEFI Device Path and partition handle before closing the file
+    EFI_DEVICE_PATH_PROTOCOL *efi_file_path = build_relative_efi_file_path(image);
+    EFI_HANDLE efi_part_handle = image->efi_part_handle;
+
+    fclose(image);
+    term_notready();
+
+    // 4. Prepare command line options for the target UEFI image
+    size_t cmdline_len = strlen(cmdline);
+    CHAR16 *new_cmdline = NULL;
+    EFI_STATUS status = gBS->AllocatePool(EfiLoaderData, (cmdline_len + 1) * sizeof(CHAR16), (void **)&new_cmdline);
+    if (status) {
+        panic(true, "efi-handover: Memory allocation failure for boot options");
+    }
+    for (size_t i = 0; i < cmdline_len + 1; i++) {
+        new_cmdline[i] = cmdline[i];
+    }
+
+    pmm_release_uefi_mem();
+
+    EFI_HANDLE new_handle = 0;
+
+    // 5. Load the image natively via firmware filesystem drivers using raw EFI_DEVICE_PATH.
+    // This ensures that the TPM measures the actual file on disk, keeping PCR 4 clean
+    // and preventing Windows BitLocker from tripping on dual-boot setups.
+    status = gBS->LoadImage(FALSE, efi_image_handle,
+                            efi_file_path,
+                            NULL, 0, &new_handle);
+    if (status) {
+        panic(false, "efi-handover: LoadImage failure (%X). CheckSecure Boot keys!", (uint64_t)status);
+    }
+
+    // 6. Retrieve Loaded Image Protocol to pass custom load options (cmdline)
+    EFI_GUID loaded_img_prot_guid = EFI_LOADED_IMAGE_PROTOCOL_GUID;
+    EFI_LOADED_IMAGE_PROTOCOL *new_handle_loaded_image = NULL;
+    status = gBS->HandleProtocol(new_handle, &loaded_img_prot_guid, (void **)&new_handle_loaded_image);
+    if (status) {
+        panic(false, "efi-handover: HandleProtocol failure (%X)", (uint64_t)status);
+    }
+
+    if (efi_part_handle != 0) {
+        new_handle_loaded_image->DeviceHandle = efi_part_handle;
+    }
+
+    new_handle_loaded_image->FilePath = efi_file_path;
+    new_handle_loaded_image->LoadOptionsSize = (cmdline_len + 1) * sizeof(CHAR16); 
+    new_handle_loaded_image->LoadOptions = new_cmdline;
+
+    bli_on_boot();
+
+    // 7. Execute the UEFI image
+    UINTN exit_data_size = 0;
+    CHAR16 *exit_data = NULL;
+    EFI_STATUS exit_status = gBS->StartImage(new_handle, &exit_data_size, &exit_data);
+
+    status = gBS->Exit(efi_image_handle, exit_status, exit_data_size, exit_data);
+    if (status) {
+        panic(false, "efi-handover: Exit failure (%X)", (uint64_t)status);
+    }
+
+    __builtin_unreachable();
+}
+
+
 noreturn void chainload(char *config, char *cmdline) {
     char *image_path = config_get_value(config, 0, "PATH");
     if (image_path == NULL) {

--- a/common/protos/chainload.h
+++ b/common/protos/chainload.h
@@ -5,4 +5,6 @@
 
 noreturn void chainload(char *config, char *cmdline);
 
+noreturn void chainload_handover(char *config, char *cmdline);
+
 #endif


### PR DESCRIPTION
   ### Description

   This PR implements the new `protocol: efi_handover` option proposed in the active BitLocker/TPM issue.

   ### Why this is needed:
   Currently, the standard `protocol: efi` reads the target binary into a memory buffer before passing it to `gBS->LoadImage()`. This execution from an anonymous RAM buffer alters the TPM PCR 4 measurement because Limine leaves its active footprint in the boot chain. As a result, Windows BitLocker detects a "tampered" boot path and forces the user into the recovery key screen on every dual-boot start.

   ### What this PR does:
   Instead of allocating memory and parsing the image manually, `efi_handover` uses native UEFI firmware services:
   1. It resolves the relative `EFI_DEVICE_PATH` (`efi_file_path`) and partition handle of the target image.
   2. It closes the file handle in Limine immediately, keeping the RAM clean.
   3. It passes the raw `EFI_DEVICE_PATH` directly to `gBS->LoadImage(FALSE, ...)`, allowing the motherboard's native filesystem drivers to handle the load and signature checks natively.
   4. It starts the image cleanly via `gBS->StartImage()`.

   This keeps the TPM measurements clean, allowing seamless dual-booting with Windows BitLocker active, without requiring double-POST reboots via `efi_boot_entry`.

   ### Testing status:
   - The code builds flawlessly under `clang -target x86_64-unknown-none-elf`.
   - I am running a pure Arch Linux system on my bare-metal machine without Windows, so I was unable to personally test the BitLocker bypass.
   - *I am opening this as a Draft PR* so the author of the issue or other contributors with dual-boot Windows + TPM configurations can test the compiled binary and confirm the fix.
   
