### PR TITLE
lib/bgrt: natively restore OEM firmware logo upon OS handoff

### DIFF
--- a/common/lib/acpi.h
+++ b/common/lib/acpi.h
@@ -199,6 +199,16 @@ struct madt_core_pic {
 #define MADT_CORE_PIC_ENABLED        ((uint32_t)1 << 0)
 #define MADT_CORE_PIC_ONLINE_CAPABLE ((uint32_t)1 << 1)
 
+struct acpi_bgrt {
+    struct sdt header;
+    uint16_t version;
+    uint8_t status;
+    uint8_t image_type;
+    uint64_t image_address;
+    uint32_t image_offset_x;
+    uint32_t image_offset_y;
+} __attribute__((packed));
+
 uint8_t acpi_checksum(void *ptr, size_t size);
 void   *acpi_get_rsdp(void);
 

--- a/common/lib/bgrt.c
+++ b/common/lib/bgrt.c
@@ -1,0 +1,82 @@
+#include <stddef.h>
+#include <stdint.h>
+#include <lib/bgrt.h>
+#include <lib/acpi.h>
+#include <lib/config.h>
+#include <lib/libc.h>
+#include <lib/misc.h>
+
+#if defined (UEFI)
+
+void bgrt_restore(uint64_t fb_width, uint64_t fb_height) {
+    if (!firmware_logo) {
+        return;
+    }
+
+    struct acpi_bgrt *bgrt = acpi_get_table("BGRT", 0);
+    if (bgrt == NULL) {
+        return;
+    }
+
+    if (bgrt->header.length < sizeof(struct acpi_bgrt)) {
+        return;
+    }
+
+    if (bgrt->version != 1) {
+        return;
+    }
+
+    if (bgrt->image_address > UINTPTR_MAX) {
+        return;
+    }
+
+    bgrt->status &= ~1;
+    
+    uint8_t *bmp = (uint8_t *)(uintptr_t)bgrt->image_address;
+    if (bmp != NULL && bmp[0] == 'B' && bmp[1] == 'M') {
+        // No file size check - often 0
+        uint32_t dib_header_size;
+        memcpy(&dib_header_size, &bmp[14], sizeof(dib_header_size));
+        
+        uint32_t bmp_width = 0;
+        uint32_t bmp_height = 0;
+
+        if (dib_header_size >= 40) {
+            int32_t bmp_height_raw;
+            memcpy(&bmp_width, &bmp[18], sizeof(bmp_width));
+            memcpy(&bmp_height_raw, &bmp[22], sizeof(bmp_height_raw));
+
+            bmp_height = (uint32_t)(bmp_height_raw < 0 ? -bmp_height_raw : bmp_height_raw);
+        } else if (dib_header_size == 12) {
+            uint16_t bmp_width_raw;
+            uint16_t bmp_height_raw;
+            memcpy(&bmp_width_raw, &bmp[18], sizeof(bmp_width_raw));
+            memcpy(&bmp_height_raw, &bmp[20], sizeof(bmp_height_raw));
+
+            bmp_width = bmp_width_raw;
+            bmp_height = bmp_height_raw;
+        }
+
+        if (bmp_width > 0 && bmp_height > 0) {
+            if (fb_width >= bmp_width) {
+                bgrt->image_offset_x = (fb_width - bmp_width) / 2;
+            }
+
+            if (fb_height >= bmp_height) {
+                bgrt->image_offset_y = (fb_height - bmp_height) / 2;
+            }
+        }
+    }
+
+    bgrt->header.checksum = 0;
+    bgrt->header.checksum = 256 - acpi_checksum(bgrt, bgrt->header.length);
+}
+
+#else
+
+void bgrt_restore(uint64_t fb_width, uint64_t fb_height) {
+    (void)fb_width;
+    (void)fb_height;
+}
+
+#endif

--- a/common/lib/bgrt.h
+++ b/common/lib/bgrt.h
@@ -1,0 +1,7 @@
+#ifndef LIB__BGRT_H__
+#define LIB__BGRT_H__
+#include <stdint.h>
+
+void bgrt_restore(uint64_t fb_width, uint64_t fb_height);
+
+#endif

--- a/common/lib/fb.c
+++ b/common/lib/fb.c
@@ -9,6 +9,7 @@
 #include <mm/mtrr.h>
 #include <mm/efi_pt.h>
 #include <sys/cpu.h>
+#include <lib/bgrt.h>
 
 struct fb_info *fb_fbs;
 size_t fb_fbs_count = 0;
@@ -77,6 +78,12 @@ void fb_init(struct fb_info **ret, size_t *_fbs_count,
     }
 #else
     (void)want_wc;
+#endif
+
+#if defined (UEFI)
+    if (!preserve_screen && *_fbs_count > 0) {
+        bgrt_restore((*ret)[0].framebuffer_width, (*ret)[0].framebuffer_height);
+    }
 #endif
 }
 

--- a/common/lib/misc.h
+++ b/common/lib/misc.h
@@ -38,7 +38,7 @@ extern struct volume *boot_volume;
 extern bool stage3_loaded;
 #endif
 
-extern bool quiet, serial, editor_enabled, help_hidden, hash_mismatch_panic, secure_boot_active, measured_boot;
+extern bool quiet, serial, editor_enabled, help_hidden, hash_mismatch_panic, secure_boot_active, measured_boot, firmware_logo;
 
 extern uint64_t usec_at_bootloader_entry;
 

--- a/common/lib/misc.s2.c
+++ b/common/lib/misc.s2.c
@@ -8,6 +8,7 @@ bool quiet = false;
 bool serial = false;
 bool hash_mismatch_panic = false;
 bool measured_boot = false;
+bool firmware_logo = false;
 
 uint8_t bcd_to_int(uint8_t val) {
     return (val & 0x0f) + ((val & 0xf0) >> 4) * 10;

--- a/common/menu.c
+++ b/common/menu.c
@@ -1358,6 +1358,9 @@ noreturn void _menu(bool first_run) {
     char *quiet_str = config_get_value(NULL, 0, "QUIET");
     quiet = quiet_str != NULL && strcmp(quiet_str, "yes") == 0;
 
+    char *firmware_logo_str = config_get_value(NULL, 0, "FIRMWARE_LOGO");
+    firmware_logo = firmware_logo_str != NULL && strcmp(firmware_logo_str, "yes") == 0;
+
     char *verbose_str = config_get_value(NULL, 0, "VERBOSE");
     verbose = verbose_str != NULL && strcmp(verbose_str, "yes") == 0;
 


### PR DESCRIPTION
When Limine restores the terminal before handing off to the OS, the screen is unconditionally wiped via fb_init. By clearing the 'displayed' status bit in the ACPI BGRT table, the OS is forced to natively redraw the firmware logo itself instead of rendering a "blank" OS boot screen.

As previously noted in term_fallback(), this was a known tradeoff: // XXX: Ideally we clear the screen, but that gets rid of the BGRT boot logo

To prevent off-center rendering when Limine negotiates a GOP resolution that differs from the firmware's, the active framebuffer dimensions are used to recalculate and update the BMP image offsets in the BGRT table.

The BMP headers are parsed from the physical image_address using memcpy to avoid strict aliasing violations. It correctly supports both modern BITMAPINFOHEADER and legacy BITMAPCOREHEADER formats, and handles top-down bitmaps via signed height interpretation.

The ACPI table checksum is fully recomputed after all fields are modified, maintaining spec compliance.

This behaviour is entirely gated behind the opt-in firmware_logo: yes configuration flag and is only active on UEFI targets.

Tested on x86_64 UEFI bare metal.

Assisted-by: Antigravity:gemini-3.1-pro