### PR TITLE
protos/linux: Align concatenated initrd modules to 4 bytes

### DIFF
--- a/common/protos/linux_risc.c
+++ b/common/protos/linux_risc.c
@@ -139,7 +139,12 @@ static void load_module(struct boot_param *p, char *config) {
             panic(true, "linux: failed to open module `%s`. Is the path correct?", module_path);
         }
 
-        total_size = CHECKED_ADD(total_size, module_file->size,
+        // Align each module to 4 bytes so the kernel's initramfs unpacker,
+        // which only accepts a raw cpio header at a 4-byte aligned offset,
+        // can find concatenated archives.
+        size_t module_size = ALIGN_UP(module_file->size, 4,
+            panic(true, "linux: Total module size overflow"));
+        total_size = CHECKED_ADD(total_size, module_size,
             panic(true, "linux: Total module size overflow"));
 
         modules[i] = module_file;
@@ -164,7 +169,8 @@ static void load_module(struct boot_param *p, char *config) {
 
         printv("linux: loaded module `%s` at %p, size %U\n", module_path,
                p->module_base + offset, (uint64_t)module_size);
-        offset += module_size;
+        offset += ALIGN_UP(module_size, 4,
+            panic(true, "linux: Total module size overflow"));
     }
 
     pmm_free(modules, module_count * sizeof(struct file_handle *));

--- a/common/protos/linux_x86.c
+++ b/common/protos/linux_x86.c
@@ -488,7 +488,12 @@ noreturn void linux_load(char *config, char *cmdline) {
         )) == NULL)
             panic(true, "linux: Failed to open module with path `%s`. Is the path correct?", module_path);
 
-        size_of_all_modules = CHECKED_ADD(size_of_all_modules, module->size,
+        // Align each module to 4 bytes so the kernel's initramfs unpacker,
+        // which only accepts a raw cpio header at a 4-byte aligned offset,
+        // can find concatenated archives.
+        size_t module_size = ALIGN_UP(module->size, 4,
+            panic(true, "linux: Total module size overflow"));
+        size_of_all_modules = CHECKED_ADD(size_of_all_modules, module_size,
             panic(true, "linux: Total module size overflow"));
 
         modules[i] = module;
@@ -538,15 +543,21 @@ noreturn void linux_load(char *config, char *cmdline) {
         if (module_path == NULL)
             break;
 
-        fread(modules[i], (void *)_modules_mem_base, 0, modules[i]->size);
+        size_t module_size = modules[i]->size;
+        size_t padded_size = ALIGN_UP(module_size, 4,
+            panic(true, "linux: Total module size overflow"));
+
+        fread(modules[i], (void *)_modules_mem_base, 0, module_size);
+        memset((void *)(_modules_mem_base + module_size), 0,
+               padded_size - module_size);
 
 #if defined (UEFI)
         tpm_measure_path(TPM_PCR_BOOT_AUTH, TPM_EV_IPL, "module_path: ", module_path);
         tpm_measure(TPM_PCR_LOADED_IMAGES, TPM_EV_IPL,
-                    (void *)_modules_mem_base, modules[i]->size, "module_path: ", module_path);
+                    (void *)_modules_mem_base, module_size, "module_path: ", module_path);
 #endif
 
-        _modules_mem_base += modules[i]->size;
+        _modules_mem_base += padded_size;
 
         fclose(modules[i]);
     }


### PR DESCRIPTION
The Linux initramfs unpacker only accepts a raw newc cpio header when the
current offset in the ramdisk buffer is 4-byte aligned.

Limine currently concatenates `module_path` files byte for byte, so an
uncompressed cpio appended after a compressed initrd whose size is not a
multiple of 4 lands at an unaligned offset and the kernel reports:

```
Initramfs unpacking failed: invalid magic at start of compressed archive
```

This pads each module to a 4-byte boundary and zeroes the gap, matching
GRUB and systemd-boot's EFI stub. Applies to both `linux_x86.c` and
`linux_risc.c`.

Tested on x86_64 UEFI with a zstd-compressed main initrd followed by an
uncompressed newc cpio.
