### PR TITLE
lib/getchar: Add configurable keyboard layout support

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,6 @@
+The following are the authors/maintainers of Limine with the rights to push commits to trunk and create
+releases signed with their GPG keys.
+
+- Mintsuki, GPG ID 05D29860D0A0668AAEFB9D691F3C021BECA23821.
+- Iczelia (Kamila Szewczyk), GPG ID 6C222EA6B2BD216AA406516AC868F0B6DE38409D.
+

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -127,6 +127,12 @@ Miscellaneous:
   "displayed" status bit in the ACPI BGRT table so the OS redraws the logo
   itself. The image is re-centred for the active resolution. UEFI only;
   defaults to `no`.
+* `keyboard_layout` - Specifies a keyboard layout to remap printable
+  keystrokes to before they reach the menu and editor. Currently only
+  `dvorak` is supported. If unset, no remapping is applied and keystrokes
+  are used as-is. This assumes the underlying firmware resolves keystrokes
+  as US-QWERTY; on firmware/keyboard combinations that already resolve a
+  different layout natively, this option may produce incorrect output.
 
 Limine interface control options:
 

--- a/common/lib/getchar.c
+++ b/common/lib/getchar.c
@@ -5,6 +5,7 @@
 #include <lib/misc.h>
 #include <lib/term.h>
 #include <lib/print.h>
+#include <lib/config.h>
 #if defined (BIOS)
 #  include <lib/real.h>
 #elif defined (UEFI)
@@ -12,6 +13,36 @@
 #endif
 #include <drivers/serial.h>
 #include <sys/cpu.h>
+
+
+static int dvorak_enabled = -1;
+
+static const char qwerty_to_dvorak[128] = {
+    ['q']='\'', ['w']=',', ['e']='.', ['r']='p', ['t']='y',
+    ['y']='f', ['u']='g', ['i']='c', ['o']='r', ['p']='l',
+    ['[']='/', [']']='=', ['\\']='\\', ['a']='a', ['s']='o',
+    ['d']='e', ['f']='u', ['g']='i', ['h']='d', ['j']='h',
+    ['k']='t', ['l']='n', [';']='s', ['\'']='-', ['z']=';', ['x']='q',
+    ['c']='j', ['v']='k', ['b']='x', ['n']='b', ['m']='m',
+    [',']='w', ['.']='v', ['/']='z',
+
+    ['Q']='\"', ['W']='<', ['E']='>', ['R']='P', ['T']='Y',
+    ['Y']='F', ['U']='G', ['I']='C', ['O']='R', ['P']='L',
+    ['{']='?', ['}']='+', ['|']='|', ['A']='A', ['S']='O',
+    ['D']='E', ['F']='U', ['G']='I', ['H']='D', ['J']='H',
+    ['K']='T', ['L']='N', [':']='S', ['"']='_', ['Z']=':', ['X']='Q',
+    ['C']='J', ['V']='K', ['B']='X', ['N']='B', ['M']='M',
+    ['<']='W', ['>']='V', ['?']='Z',
+};
+
+static bool keyboard_is_dvorak(void) {
+    if(dvorak_enabled == -1) {
+        char *layout = config_get_value(NULL, 0, "keyboard_layout");
+        dvorak_enabled = (layout != NULL && strcasecmp(layout, "dvorak") == 0);
+    }
+    return dvorak_enabled;
+}
+
 
 int getchar(void) {
     for (;;) {
@@ -104,6 +135,11 @@ int getchar_internal(uint8_t scancode, uint8_t ascii, uint32_t shift_state) {
     if (ascii < 0x20 || ascii > 0x7e) {
         return -1;
     }
+
+    if (keyboard_is_dvorak() && qwerty_to_dvorak[(uint8_t)ascii] != 0) {
+        return qwerty_to_dvorak[(uint8_t)ascii];
+    }
+
     return ascii;
 }
 

--- a/common/lib/getchar.c
+++ b/common/lib/getchar.c
@@ -5,7 +5,7 @@
 #include <lib/misc.h>
 #include <lib/term.h>
 #include <lib/print.h>
-#include <lib/config.h>
+#include <menu.h>
 #if defined (BIOS)
 #  include <lib/real.h>
 #elif defined (UEFI)
@@ -13,9 +13,6 @@
 #endif
 #include <drivers/serial.h>
 #include <sys/cpu.h>
-
-
-static int dvorak_enabled = -1;
 
 static const char qwerty_to_dvorak[128] = {
     ['q']='\'', ['w']=',', ['e']='.', ['r']='p', ['t']='y',
@@ -34,14 +31,6 @@ static const char qwerty_to_dvorak[128] = {
     ['C']='J', ['V']='K', ['B']='X', ['N']='B', ['M']='M',
     ['<']='W', ['>']='V', ['?']='Z',
 };
-
-static bool keyboard_is_dvorak(void) {
-    if(dvorak_enabled == -1) {
-        char *layout = config_get_value(NULL, 0, "keyboard_layout");
-        dvorak_enabled = (layout != NULL && strcasecmp(layout, "dvorak") == 0);
-    }
-    return dvorak_enabled;
-}
 
 
 int getchar(void) {
@@ -136,7 +125,7 @@ int getchar_internal(uint8_t scancode, uint8_t ascii, uint32_t shift_state) {
         return -1;
     }
 
-    if (keyboard_is_dvorak() && qwerty_to_dvorak[(uint8_t)ascii] != 0) {
+    if (current_keyboard_layout == KEYBOARD_LAYOUT_DVORAK && qwerty_to_dvorak[(uint8_t)ascii] != 0) {
         return qwerty_to_dvorak[(uint8_t)ascii];
     }
 

--- a/common/menu.c
+++ b/common/menu.c
@@ -48,6 +48,17 @@ static char menu_branding_colour[24] = "\e[38;2;0;170;170m";
 
 static char *menu_branding = NULL;
 
+enum keyboard_layout current_keyboard_layout = KEYBOARD_LAYOUT_UNKNOWN;
+
+static void keyboard_layout_init(void) {
+    char *layout = config_get_value(NULL, 0, "keyboard_layout");
+    if (layout != NULL && strcasecmp(layout, "dvorak") == 0) {
+        current_keyboard_layout = KEYBOARD_LAYOUT_DVORAK;
+    } else {
+        current_keyboard_layout = KEYBOARD_LAYOUT_QWERTY;
+    }
+}
+
 static char *append_uint_dec(char *p, uint64_t val) {
     char buf[20];
     size_t i = 0;
@@ -1161,7 +1172,7 @@ static void menu_init_term(void) {
 #elif defined (UEFI)
     char *graphics = "yes";
 #endif
-
+    keyboard_layout_init();
     if (graphics == NULL || strcmp(graphics, "no") != 0) {
         size_t req_width = 0, req_height = 0, req_bpp = 0;
 

--- a/common/menu.h
+++ b/common/menu.h
@@ -19,4 +19,12 @@ char *config_entry_editor(const char *title, const char *orig_entry);
 
 extern bool booting_from_editor;
 
+enum keyboard_layout {
+    KEYBOARD_LAYOUT_UNKNOWN = -1,
+    KEYBOARD_LAYOUT_QWERTY,
+    KEYBOARD_LAYOUT_DVORAK,
+};
+
+extern enum keyboard_layout current_keyboard_layout;
+
 #endif

--- a/test/limine.conf
+++ b/test/limine.conf
@@ -9,6 +9,7 @@ verbose: yes
 wallpaper: ${WALLPAPER_PATH}
 wallpaper_style: centered
 backdrop: 008080
+keyboard_layout: dvorak
 
 /Limine Test
     comment: Test of the Limine boot protocol. ${ARCH} ${FW_TYPE}

--- a/test/limine.conf
+++ b/test/limine.conf
@@ -9,7 +9,6 @@ verbose: yes
 wallpaper: ${WALLPAPER_PATH}
 wallpaper_style: centered
 backdrop: 008080
-keyboard_layout: dvorak
 
 /Limine Test
     comment: Test of the Limine boot protocol. ${ARCH} ${FW_TYPE}


### PR DESCRIPTION
Adds support for configurable keyboard layouts via the `keyboard_layout`
configuration option.

This PR implements the Dvorak keyboard layout.