### PR TITLE
common/mm/pmm.s2: Handle reserved regions inside usable memory

### DIFF
--- a/3RDPARTY.md
+++ b/3RDPARTY.md
@@ -61,6 +61,9 @@ manipulating Flat Device Trees.
 - [pdgzip](https://github.com/iczelia/pdgzip) (0BSD) is used to provide the
 transparent gzip decompression layer for loaded files.
 
+- [BLAKE2](https://github.com/BLAKE2/BLAKE2/blob/master/ref/blake2b-ref.c)
+  (CC0-1.0) is used as the basis for the portable BLAKE2 implementation.
+
 Note that some of these projects, or parts of them, are provided under
 dual-licensing, in which case, in the above list, the only license mentioned is
 the one chosen by the Limine developers. Refer to each individual project's

--- a/3RDPARTY.md
+++ b/3RDPARTY.md
@@ -61,9 +61,6 @@ manipulating Flat Device Trees.
 - [pdgzip](https://github.com/iczelia/pdgzip) (0BSD) is used to provide the
 transparent gzip decompression layer for loaded files.
 
-- [BLAKE2](https://github.com/BLAKE2/BLAKE2/blob/master/ref/blake2b-ref.c)
-  (CC0-1.0) is used as the basis for the portable BLAKE2 implementation.
-
 Note that some of these projects, or parts of them, are provided under
 dual-licensing, in which case, in the above list, the only license mentioned is
 the one chosen by the Limine developers. Refer to each individual project's

--- a/common/mm/pmm.s2.c
+++ b/common/mm/pmm.s2.c
@@ -151,9 +151,14 @@ void pmm_sanitise_entries(struct memmap_entry *m, size_t *_count, bool align_ent
             }
 
             if ( (res_base >= base && res_base < top)
-              && (res_top  >= base && res_top  < top) ) {
-                // TODO actually handle splitting off usable chunks
-                panic(false, "A non-usable memory map entry is inside a usable section.");
+              && (res_top  >= base && res_top  < top)
+              && (m[j].type != MEMMAP_USABLE) ) {
+                m[count] = m[i];
+                m[count].base = res_top;
+                m[count].length = top - res_top;
+                count++;
+
+                top = res_base;
             }
 
             if (res_base >= base && res_base < top) {


### PR DESCRIPTION
Split off usable chunks around reserved regions.

This removes a case where valid memory maps could trigger a panic during in pmm_sanitise_entries.