### PR TITLE
config: support backslash-newline line continuation (#611)

### DIFF
--- a/common/lib/config.c
+++ b/common/lib/config.c
@@ -409,34 +409,54 @@ int init_config(size_t config_size) {
 
     // add trailing newline if not present
     config_addr[config_size - 2] = '\n';
-
+    
     size_t config_alloc_size = config_size;
 
-    // remove windows carriage returns and spaces at the start and end of lines, if any
-    for (size_t i = 0; i < config_size; i++) {
-        size_t skip = 0;
-        if (config_addr[i] == ' ' || config_addr[i] == '\t') {
-            while (i + skip < config_size && (config_addr[i + skip] == ' ' || config_addr[i + skip] == '\t')) {
-                skip++;
+    // handle backslash-newline line continuation
+    size_t write = 0;
+    for (size_t read = 0; read < config_size; read++) {
+        if (config_addr[read] == '\\' && read + 1 < config_size) {
+            if (config_addr[read + 1] == '\n') {
+                read++;
+                continue;
             }
-            if (i + skip < config_size && config_addr[i + skip] == '\n') {
-                goto skip_loop;
+            if (config_addr[read + 1] == '\r' && read + 2 < config_size && config_addr[read + 2] == '\n') {
+                read += 2;
+                continue;
             }
-            skip = 0;
         }
-        while (i + skip < config_size
-            && ((config_addr[i + skip] == '\r')
-                || ((!i || config_addr[i - 1] == '\n') && (config_addr[i + skip] == ' ' || config_addr[i + skip] == '\t')))
-        ) {
-            skip++;
+        config_addr[write++] = config_addr[read];
+    }
+
+    config_size = write;
+
+    // Remove carriage returns and leading/trailing whitespace from lines
+    {
+        size_t trim_write = 0;
+        bool at_line_start = true;
+        for (size_t read = 0; read < config_size; read++) {
+            char c = config_addr[read];
+
+            if (c == '\r') {
+                continue;
+            }
+
+            if (at_line_start && (c == ' ' || c == '\t')) {
+                continue;
+            }
+
+            if (c == '\n') {
+                while (trim_write > 0 && (config_addr[trim_write - 1] == ' ' || config_addr[trim_write - 1] == '\t')) {
+                    trim_write--;
+                }
+                at_line_start = true;
+            } else {
+                at_line_start = false;
+            }
+
+            config_addr[trim_write++] = c;
         }
-skip_loop:
-        if (skip) {
-            for (size_t j = i; j < config_size - skip; j++)
-                config_addr[j] = config_addr[j + skip];
-            config_size -= skip;
-            i--; // re-examine character shifted into position i
-        }
+        config_size = trim_write;
     }
 
     // Load macros


### PR DESCRIPTION
**Add backslash-newline line continuation to config parser.**

O(n) two-pointer approach.
Handles Unix (\n) and Windows (\r\n) line endings.

**Example:**
  CMDLINE: root=/dev/sda1 rw quiet \
      zswap.enabled=0

Becomes one continuous line.

Tested with 20 unit tests + 100K fuzz + 50K comparisons vs old code.

**_Fixes #611_**

**Test Files :** 
[test_compare.c](https://github.com/user-attachments/files/30767339/test_compare.c)
[test_full.c](https://github.com/user-attachments/files/30767340/test_full.c)
