### PR TITLE
lib/getchar: Bound BIOS waits with a TSC deadline

### DIFF
--- a/common/lib/getchar.c
+++ b/common/lib/getchar.c
@@ -175,7 +175,8 @@ int getchar_internal(uint8_t scancode, uint8_t ascii, uint32_t shift_state) {
 }
 
 #if defined (BIOS)
-int _pit_sleep_and_quit_on_keypress(uint32_t ticks, uint32_t aux_poll);
+int _pit_sleep_and_quit_on_keypress(uint32_t ticks, uint32_t aux_poll,
+                                    uint64_t tsc_deadline);
 
 // XXX: sync with lib/sleep.asm_bios_ia32.
 #define PIT_SLEEP_AUX_BREAK (-100)
@@ -273,6 +274,10 @@ static int sleep_ms_core(uint64_t milliseconds, int mouse_mode) {
         return 0;
     }
 
+    uint64_t tsc_deadline = rdtsc_deadline(milliseconds > UINT64_MAX / 1000
+                                         ? UINT64_MAX
+                                         : milliseconds * 1000);
+
     // Hand over mouse state accumulated while nobody was listening (e.g. a
     // pointer position preserved across a menu re-entry) before blocking.
     if (mouse_mode == MOUSE_MODE_FULL && mouse_state_pending()) {
@@ -284,7 +289,7 @@ static int sleep_ms_core(uint64_t milliseconds, int mouse_mode) {
     bool aux_poll = mouse_present();
 
     if (!serial && !aux_poll) {
-        return _pit_sleep_and_quit_on_keypress(ticks, 0);
+        return _pit_sleep_and_quit_on_keypress(ticks, 0, tsc_deadline);
     }
 
     uint32_t start = mmind(0x46c);
@@ -293,7 +298,7 @@ static int sleep_ms_core(uint64_t milliseconds, int mouse_mode) {
     for (;;) {
         uint32_t remaining = ticks - elapsed;
         int ret = _pit_sleep_and_quit_on_keypress(serial && remaining > 1 ? 1 : remaining,
-                                                  aux_poll);
+                                                  aux_poll, tsc_deadline);
 
         if (ret == PIT_SLEEP_AUX_BREAK) {
             int ev = mouse_process_pending();
@@ -313,6 +318,10 @@ static int sleep_ms_core(uint64_t milliseconds, int mouse_mode) {
             if (ret != 0) {
                 return ret;
             }
+        }
+
+        if (rdtsc_deadline_expired(tsc_deadline)) {
+            return 0;
         }
 
         uint32_t now = mmind(0x46c);

--- a/common/lib/sleep.asm_bios_ia32
+++ b/common/lib/sleep.asm_bios_ia32
@@ -2,6 +2,8 @@ section .realmode
 
 int_08_ticks_counter: dd 0
 int_08_callback:      dd 0
+pit_ticks:            dd 0
+tsc_deadline:         dq 0
 
 int_08_isr:
     bits 16
@@ -20,8 +22,13 @@ _pit_sleep_and_quit_on_keypress:
     mov dword [int_08_callback], edx
     mov dword [0x08*4], int_08_isr
 
-    ; pit_ticks in edx
-    mov edx, dword [esp+4]
+    mov eax, dword [esp+4]
+    mov dword [pit_ticks], eax
+
+    mov eax, dword [esp+12]
+    mov dword [tsc_deadline], eax
+    mov eax, dword [esp+16]
+    mov dword [tsc_deadline+4], eax
 
     ; whether to also break out on pending PS/2 aux (mouse) data
     mov eax, dword [esp+8]
@@ -74,9 +81,23 @@ _pit_sleep_and_quit_on_keypress:
     mov byte [.aux_hit], 0
 
   .loop:
-    cmp dword [int_08_ticks_counter], edx
+    mov eax, dword [int_08_ticks_counter]
+    cmp eax, dword [cs:pit_ticks]
     jae .done
 
+    cmp dword [cs:tsc_deadline+4], 0
+    jne .check_tsc
+    cmp dword [cs:tsc_deadline], 0
+    je .check_aux
+  .check_tsc:
+    rdtsc
+    cmp edx, dword [cs:tsc_deadline+4]
+    ja .done
+    jb .check_aux
+    cmp eax, dword [cs:tsc_deadline]
+    jae .done
+
+  .check_aux:
     cmp byte [.aux_poll], 0
     je .no_aux
     in al, 0x64

--- a/common/sys/cpu.h
+++ b/common/sys/cpu.h
@@ -556,6 +556,42 @@ static inline uint64_t rdtsc_usec(void) {
          + exec_ticks % tsc_freq * 1000000 / tsc_freq;
 }
 
+static inline uint64_t rdtsc_deadline(uint64_t us) {
+    if (tsc_freq == 0) {
+        return 0;
+    }
+
+    uint64_t seconds = us / 1000000;
+    uint64_t remainder = us % 1000000;
+
+    uint64_t ticks;
+    if (__builtin_mul_overflow(seconds, tsc_freq, &ticks)) {
+        return UINT64_MAX;
+    }
+
+    uint64_t remainder_ticks;
+    if (__builtin_mul_overflow(remainder, tsc_freq / 1000000,
+                               &remainder_ticks)) {
+        return UINT64_MAX;
+    }
+    remainder_ticks += remainder * (tsc_freq % 1000000) / 1000000;
+
+    if (__builtin_add_overflow(ticks, remainder_ticks, &ticks)) {
+        return UINT64_MAX;
+    }
+
+    uint64_t now = rdtsc();
+    if (__builtin_add_overflow(now, ticks, &ticks)) {
+        return UINT64_MAX;
+    }
+
+    return ticks;
+}
+
+static inline bool rdtsc_deadline_expired(uint64_t deadline) {
+    return deadline != 0 && rdtsc() >= deadline;
+}
+
 static inline void stall(uint64_t us) {
     uint64_t ticks = (tsc_freq * us + 999999) / 1000000;
     uint64_t next_stop = rdtsc() + ticks;


### PR DESCRIPTION
## Description

BIOS menu delays currently depend on IRQ0 advancing the PIT tick counter. If those interrupts are not delivered, `_pit_sleep_and_quit_on_keypress()` can wait indefinitely.

Retain the existing PIT-based timing and input handling, but also calculate a deadline using the already calibrated TSC. The real-mode wait loop exits when either the requested PIT tick count or the TSC deadline is reached.

A zero deadline represents an unavailable TSC frequency and preserves the existing PIT-only behavior.

This does not change UEFI builds or BIOS serial-port discovery.

## Testing

- Built the BIOS code with warnings treated as errors.
- Verified an automatic menu timeout under QEMU without serial input.
- Verified an automatic menu timeout with COM1 enabled.
- Verified that keyboard input still interrupts the timeout.
- Verified with an instrumented QEMU build that the timeout completes using the TSC deadline when the IRQ0 tick counter is prevented from advancing.