### PR TITLE
protos, menu: Add global terse option to hide loading messages

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -124,6 +124,9 @@ Miscellaneous:
   image, in RRGGBB format.
 * `verbose` - If set to `yes`, print additional information during boot.
   Defaults to not verbose.
+* `terse` - If set to `yes`, suppress informational loading messages (such as
+  "Loading kernel" and "Loading module") when booting any entry. The menu and
+  any error or panic messages remain unaffected. Defaults to `no`.
 * `randomise_memory` - If set to `yes`, randomise the contents of RAM at bootup
   in order to find bugs related to non zeroed memory or for security reasons.
   This option will slow down boot time significantly. In the case of IA-32,

--- a/common/lib/misc.h
+++ b/common/lib/misc.h
@@ -42,7 +42,7 @@ extern bool stage3_loaded;
 extern uintptr_t __stack_chk_guard;
 void reseed_stack_guard(void);
 
-extern bool quiet, serial, editor_enabled, help_hidden, hash_mismatch_panic, secure_boot_active, measured_boot, firmware_logo;
+extern bool quiet, terse, serial, editor_enabled, help_hidden, hash_mismatch_panic, secure_boot_active, measured_boot, firmware_logo;
 
 // What is drawn rather than where it goes: a COM_OUTPUT build sets this on
 // every port and transmits on BIOS alone.

--- a/common/lib/misc.s2.c
+++ b/common/lib/misc.s2.c
@@ -26,6 +26,7 @@ noreturn void __stack_chk_fail_local(void) {
 
 bool verbose = false;
 bool quiet = false;
+bool terse = false;
 bool serial = false;
 bool hash_mismatch_panic = false;
 bool measured_boot = false;

--- a/common/menu.c
+++ b/common/menu.c
@@ -1506,6 +1506,9 @@ noreturn void _menu(bool first_run) {
     char *verbose_str = config_get_value(NULL, 0, "VERBOSE");
     verbose = verbose_str != NULL && strcmp(verbose_str, "yes") == 0;
 
+    char *terse_str = config_get_value(NULL, 0, "TERSE");
+    terse = terse_str != NULL && strcmp(terse_str, "yes") == 0;
+
     char *serial_str = config_get_value(NULL, 0, "SERIAL");
     serial =
 #if defined (UEFI)

--- a/common/protos/limine.c
+++ b/common/protos/limine.c
@@ -546,7 +546,9 @@ noreturn void limine_load(char *config, char *cmdline) {
         panic(true, "limine: Executable path not specified");
     }
 
-    print("limine: Loading executable `%#`...\n", kernel_path);
+    if (!terse) {
+        print("limine: Loading executable `%#`...\n", kernel_path);
+    }
 
     struct file_handle *kernel_file;
     if ((kernel_file = uri_open(kernel_path, MEMMAP_BOOTLOADER_RECLAIMABLE, false
@@ -1401,7 +1403,9 @@ FEAT_START
             module_cmdline = module_cmdline ? strdup(module_cmdline) : "";
         }
 
-        print("limine: Loading module `%#`...\n", module_path);
+        if (!terse) {
+            print("limine: Loading module `%#`...\n", module_path);
+        }
 
         struct file_handle *f;
         // On IA-32 under measured boot, refuse >4 GiB allocations: firmware's

--- a/common/protos/linux_risc.c
+++ b/common/protos/linux_risc.c
@@ -132,7 +132,9 @@ static void load_module(struct boot_param *p, char *config) {
     for (size_t i = 0; i < module_count; i++) {
         char *module_path = config_get_value(config, i, "MODULE_PATH");
 
-        print("linux: Loading module `%#`...\n", module_path);
+        if (!terse) {
+            print("linux: Loading module `%#`...\n", module_path);
+        }
 
         struct file_handle *module_file = uri_open(module_path, MEMMAP_BOOTLOADER_RECLAIMABLE, false);
         if (!module_file) {
@@ -511,7 +513,9 @@ noreturn void linux_load(char *config, char *cmdline) {
         panic(true, "linux: Kernel path not specified");
     }
 
-    print("linux: Loading kernel `%#`...\n", kernel_path);
+    if (!terse) {
+        print("linux: Loading kernel `%#`...\n", kernel_path);
+    }
 
     if ((kernel_file = uri_open(kernel_path, MEMMAP_BOOTLOADER_RECLAIMABLE, false)) == NULL) {
         panic(true, "linux: failed to open kernel `%s`. Is the path correct?", kernel_path);

--- a/common/protos/linux_x86.c
+++ b/common/protos/linux_x86.c
@@ -308,7 +308,9 @@ noreturn void linux_load(char *config, char *cmdline) {
         panic(true, "linux: Kernel path not specified");
     }
 
-    print("linux: Loading kernel `%#`...\n", kernel_path);
+    if (!terse) {
+        print("linux: Loading kernel `%#`...\n", kernel_path);
+    }
 
     if ((kernel_file = uri_open(kernel_path, MEMMAP_BOOTLOADER_RECLAIMABLE,
 #if defined (__i386__)
@@ -514,7 +516,9 @@ noreturn void linux_load(char *config, char *cmdline) {
         if (module_path == NULL)
             break;
 
-        print("linux: Loading module `%#`...\n", module_path);
+        if (!terse) {
+            print("linux: Loading module `%#`...\n", module_path);
+        }
 
         struct file_handle *module;
         if ((module = uri_open(module_path, MEMMAP_BOOTLOADER_RECLAIMABLE,

--- a/common/protos/multiboot1.c
+++ b/common/protos/multiboot1.c
@@ -71,7 +71,9 @@ noreturn void multiboot1_load(char *config, char *cmdline) {
         panic(true, "multiboot1: Executable path not specified");
     }
 
-    print("multiboot1: Loading executable `%#`...\n", kernel_path);
+    if (!terse) {
+        print("multiboot1: Loading executable `%#`...\n", kernel_path);
+    }
 
     if ((kernel_file = uri_open(kernel_path, MEMMAP_KERNEL_AND_MODULES, false
 #if defined (__i386__)
@@ -372,7 +374,9 @@ noreturn void multiboot1_load(char *config, char *cmdline) {
             if (module_path == NULL)
                 panic(true, "multiboot1: Module disappeared unexpectedly");
 
-            print("multiboot1: Loading module `%#`...\n", module_path);
+            if (!terse) {
+                print("multiboot1: Loading module `%#`...\n", module_path);
+            }
 
             struct file_handle *f;
             if ((f = uri_open(module_path, MEMMAP_BOOTLOADER_RECLAIMABLE, false

--- a/common/protos/multiboot2.c
+++ b/common/protos/multiboot2.c
@@ -91,7 +91,9 @@ noreturn void multiboot2_load(char *config, char* cmdline) {
         panic(true, "multiboot2: Executable path not specified");
     }
 
-    print("multiboot2: Loading executable `%#`...\n", kernel_path);
+    if (!terse) {
+        print("multiboot2: Loading executable `%#`...\n", kernel_path);
+    }
 
     if ((kernel_file = uri_open(kernel_path, MEMMAP_KERNEL_AND_MODULES, false
 #if defined (__i386__)
@@ -691,7 +693,9 @@ reloc_fail:
         char *module_path = conf_tuple.value1;
         if (!module_path) panic(true, "multiboot2: Module disappeared unexpectedly");
 
-        print("multiboot2: Loading module `%#`...\n", module_path);
+        if (!terse) {
+            print("multiboot2: Loading module `%#`...\n", module_path);
+        }
 
         struct file_handle *f;
         if ((f = uri_open(module_path, MEMMAP_BOOTLOADER_RECLAIMABLE, false


### PR DESCRIPTION
### Summary
This PR introduces a global `terse`[^1] configuration option under Miscellaneous settings in `limine.conf`. 

When set to `yes`, it suppresses informational loading messages (`Loading kernel`, `Loading executable`, and `Loading module`) across all supported boot protocols (Limine, Linux x86/RISC-V, Multiboot 1/2) upon selecting an entry. Unlike `quiet: yes`, it keeps the boot menu, editor, and warning/panic outputs fully functional and visible.

Closes #635

[^1]: https://dictionary.cambridge.org/dictionary/english/terse