### PR TITLE
Add LOADER_ARCH macro and if_loader_arch option

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -267,6 +267,9 @@ Editor control options:
 * `if_arch` - Hide the entry if the current CPU architecture is not in the
   space separated list of permitted architectures
     * see the `ARCH` macro in [Built-in macros](#built-in-macros) for a list of possible architectures
+* `if_loader_arch` - Hide the entry if the Limine binary's own architecture is
+  not in the space separated list of permitted architectures
+    * see the `LOADER_ARCH` macro in [Built-in macros](#built-in-macros) for details
 
 > **NOTE:** `uefi` and `efi_chainload` are aliases of the `efi` protocol
 > option. `bios_chainload` is an alias of the `bios` protocol option.
@@ -458,3 +461,8 @@ Limine automatically defines these macros:
   if the 64-bit extensions are available, else `ia-32`.
 * `FW_TYPE` - This built-in macro expands to `UEFI` if booted using UEFI
   firmware, or `BIOS` if booted using legacy x86 BIOS.
+* `LOADER_ARCH` - This built-in macro expands to the architecture of the Limine
+  binary itself. Possible values are the same as `ARCH`: `x86-64`, `ia-32`,
+  `aarch64`, `riscv64`, `loongarch64`. Unlike `ARCH`, this is determined at
+  compile time and does not probe CPU capabilities; the IA-32 binary always
+  expands to `ia-32` even on a CPU with 64-bit extensions.

--- a/common/lib/config.c
+++ b/common/lib/config.c
@@ -452,6 +452,12 @@ skip_loop:
     fw_type_macro->next = macros;
     macros = fw_type_macro;
 
+    struct macro *loader_arch_macro = ext_mem_alloc(sizeof(struct macro));
+    strcpy(loader_arch_macro->name, "LOADER_ARCH");
+    strcpy(loader_arch_macro->value, loader_arch());
+    loader_arch_macro->next = macros;
+    macros = loader_arch_macro;
+
     for (size_t i = 0; i < config_size;) {
         if ((config_size - i >= 3 && memcmp(config_addr + i, "\n${", 3) == 0)
          || (config_size - i >= 2 && i == 0 && memcmp(config_addr, "${", 2) == 0)) {

--- a/common/menu.c
+++ b/common/menu.c
@@ -345,6 +345,7 @@ static const char *VALID_KEYS[] = {
     "ENTRY",
     "IF_FW_TYPE",
     "IF_ARCH",
+    "IF_LOADER_ARCH",
     NULL
 };
 
@@ -898,6 +899,37 @@ static inline bool should_skip_entry(struct menu_entry *entry) {
             memcpy(buf, cur_arch, cur_arch_end - cur_arch);
             buf[cur_arch_end - cur_arch] = '\0';
             if (strcasecmp(buf, arch) == 0) {
+                skip = false;
+                break;
+            }
+            cur_arch = cur_arch_end;
+        }
+        if (skip) {
+            return true;
+        }
+    }
+    char *cur_entry_if_loader_arch = config_get_value(entry->body, 0, "IF_LOADER_ARCH");
+    if (cur_entry_if_loader_arch) {
+        const char *larch = loader_arch();
+        char *cur_arch = cur_entry_if_loader_arch;
+        bool skip = true;
+        while (*cur_arch) {
+            char *cur_arch_end = cur_arch;
+            while (*cur_arch_end && !isspace(*cur_arch_end)) {
+                ++cur_arch_end;
+            }
+            if (cur_arch == cur_arch_end) {
+                ++cur_arch;
+                continue;
+            }
+            char buf[16];
+            if (cur_arch_end - cur_arch >= 16) {
+                cur_arch = cur_arch_end;
+                continue;
+            }
+            memcpy(buf, cur_arch, cur_arch_end - cur_arch);
+            buf[cur_arch_end - cur_arch] = '\0';
+            if (strcasecmp(buf, larch) == 0) {
                 skip = false;
                 break;
             }

--- a/common/sys/cpu.h
+++ b/common/sys/cpu.h
@@ -607,4 +607,20 @@ static inline const char *current_arch(void) {
 #endif
 }
 
+static inline const char *loader_arch(void) {
+#if defined (__x86_64__)
+    return "x86-64";
+#elif defined (__i386__)
+    return "ia-32";
+#elif defined (__aarch64__)
+    return "aarch64";
+#elif defined (__riscv)
+    return "riscv64";
+#elif defined (__loongarch64)
+    return "loongarch64";
+#else
+#error "Unspecified architecture"
+#endif
+}
+
 #endif


### PR DESCRIPTION
### Summary
On x86-64 systems with IA-32 UEFI firmware, `${ARCH}` expands to `x86-64`
(reflecting CPU capability) and `if_arch: x86-64` matches. This makes it
impossible to distinguish native x64 UEFI from IA-32 UEFI on the same CPU,
so boot entries cannot be scoped to one or the other.

This PR adds `loader_arch()`, a compile-time counterpart to `current_arch()`
that always reflects the Limine binary's own architecture - `ia-32` for the
IA-32 build, `x86-64` for the x64 build - without probing CPUID.

A `LOADER_ARCH` built-in macro and a matching `if_loader_arch` local option
expose it to the config file. Existing `ARCH` / `if_arch` behaviour is
unchanged.

Example usage:
```
/Boot x64 EFI
    protocol: efi
    path: boot():/EFI/limine/BOOTX64.EFI
    if_loader_arch: x86-64

/Boot IA32 EFI
    protocol: efi
    path: boot():/EFI/limine/BOOTIA32.EFI
    if_loader_arch: ia-32
```

Closes #617 