### PR TITLE
common: Allow EL2 without VHE to boot on EL1 under base revision 6

### DIFF
--- a/common/lib/spinup.asm_aarch64
+++ b/common/lib/spinup.asm_aarch64
@@ -5,10 +5,41 @@
 // noreturn void enter_in_el1(uint64_t entry, uint64_t sp, uint64_t sctlr,
 //                            uint64_t mair, uint64_t tcr, uint64_t ttbr0,
 //                            uint64_t ttbr1, uint64_t direct_map_offset)
-// Configure EL1 state and jump to kernel. Must be called at EL1.
+// Configure EL1 state and jump to kernel.
 
 .global enter_in_el1
 enter_in_el1:
+    // Drop EL2 -> EL1
+    mrs x8, currentel
+    cmp x8, #0b1000 // EL2 ?
+    b.ne 0f 
+
+    msr sp_el0, x1
+
+    msr mair_el1, x3
+    msr tcr_el1, x4
+    msr ttbr0_el1, x5
+    msr ttbr1_el1, x6
+    msr sctlr_el1, x2
+    isb
+    dsb sy
+    isb
+
+    tlbi vmalle1
+    dsb nsh
+    isb
+
+    mov x8, #(1 << 31)
+    msr hcr_el2, x8
+
+    mov x8, #0x3c4
+    msr spsr_el2, x8
+
+    msr elr_el2, x0         
+
+    eret
+
+0:
     msr spsel, #0
     mov sp, x1
 

--- a/common/protos/limine.c
+++ b/common/protos/limine.c
@@ -530,17 +530,6 @@ noreturn void limine_load(char *config, char *cmdline) {
     uint32_t eax, ebx, ecx, edx;
 #endif
 
-#if defined (__aarch64__)
-    // Booting at EL2 without VHE is not supported.
-    if (current_el() == 2) {
-        uint64_t mmfr1;
-        asm volatile ("mrs %0, id_aa64mmfr1_el1" : "=r"(mmfr1));
-        if (!((mmfr1 >> 8) & 0xF)) {
-            panic(true, "limine: Booting at EL2 without VHE support is not supported");
-        }
-    }
-#endif
-
     char *kernel_path = config_get_value(config, 0, "PATH");
     if (kernel_path == NULL) {
         kernel_path = config_get_value(config, 0, "KERNEL_PATH");
@@ -1942,8 +1931,17 @@ FEAT_END
                             physical_base, virtual_base, direct_map_offset);
 
 #if defined (__aarch64__)
-    // Enter at EL2 with VHE if we are at EL2 (VHE check done at function entry)
-    bool want_el2 = (current_el() == 2);
+    bool want_el2 = false;
+
+    if (current_el() == 2) {
+        uint64_t mmfr1;
+        asm volatile ("mrs %0, id_aa64mmfr1_el1" : "=r"(mmfr1));
+        if (!((mmfr1 >> 8) & 0xF)) {
+            // panic(true, "limine: Booting at EL2 without VHE support is not supported");
+        } else {
+            want_el2 = true;
+        }
+    }
 #endif
 
     // MP

--- a/common/sys/smp.c
+++ b/common/sys/smp.c
@@ -510,13 +510,22 @@ static bool try_start_ap(int boot_method, uint64_t method_ptr,
             panic(false, "Invalid boot method specified");
     }
 
+    uint64_t bsp_el = current_el();
+    if (bsp_el == 2) {
+        uint64_t mmfr1;
+        asm volatile ("mrs %0, id_aa64mmfr1_el1" : "=r"(mmfr1));
+        if (!((mmfr1 >> 8) & 0xF)) {
+            bsp_el = 1;
+        }
+    }
+
     for (int i = 0; i < 1000000; i++) {
         // We do not need cache invalidation here as by the time the AP gets to
         // set this flag, it has enabled its caches
 
         if (locked_read(&passed_info->smp_tpl_booted_flag) == 1) {
             uint64_t ap_el = locked_read(&passed_info->smp_tpl_ap_el);
-            uint64_t bsp_el = current_el();
+
             if (ap_el != bsp_el) {
                 panic(false, "smp: AP started at EL%u but BSP is at EL%u",
                       (uint32_t)ap_el, (uint32_t)bsp_el);

--- a/common/sys/smp_trampoline.asm_aarch64
+++ b/common/sys/smp_trampoline.asm_aarch64
@@ -32,6 +32,24 @@ smp_trampoline_start:
 
     PICK_EL x8, 1f, 0f
 0:
+    // Test VHE support
+
+    mrs x8, id_aa64mmfr1_el1
+    and x8, x8, #(0xF << 8)
+    cbnz x8, 9f
+
+    mov x8, #(1 << 31) // RW bit (EL1 est aarch64)
+    msr hcr_el2, x8
+
+    mov x8, #0x3c5
+    msr spsr_el2, x8
+
+    adr x8, 1f
+    msr elr_el2, x8
+
+    eret
+
+9:
     // EL2 path - enable VHE and stay at EL2
 
     // Enable E2H if not already set


### PR DESCRIPTION
## Rationale

Currently, Limine triggers a hard panic on base revision 6 when booting on AArch64 systems running at EL2 without VHE (Virtualization Host Extensions). While investigating this restriction, it appeared unclear why non-VHE EL2 environments were outright excluded, as they affect a massive portion of the ARM ecosystem.

Architecturally, Virtualization Host Extensions (`FEAT_VHE`) were only introduced starting with ARMv8.1-A. A vast majority of foundational ARMv8-A hardware implements ARMv8.0 and therefore fundamentally lacks hardware VHE support. For instance, the Raspberry Pi 4 is an ARMv8.0 SoC. When booted via standard UEFI firmware layers, control is handed over to the bootloader at EL2 without VHE.

While developers could theoretically fall back to older revisions, doing so means missing out on all the critical bug fixes, enhanced CPU state guarantees during kernel handoff, etc... It feels a bit unfortunate to leave out ubiquitous hardware when a graceful EL2-to-EL1 transition path is feasible.

## Proposed Changes

This pull request introduces a clean, reliable EL2-to-EL1 transition path for non-VHE environments under base revision 6, including support for MpRequest.

This modification is entirely non-breaking, while it will require to slightly modify the protocol specification. Any platform or environment that successfully booted under base revision 6 prior to this change will continue to do so identically.

I have tested this PR on my own Raspberry Pi 4B.