### PR TITLE
menu: Stop the persistent EFI variables overriding default_entry

### DIFF
--- a/common/menu.c
+++ b/common/menu.c
@@ -1877,6 +1877,7 @@ noreturn void _menu(bool first_run) {
                 selected_entry = strtoui(default_entry, NULL, 10);
                 if (selected_entry)
                     selected_entry--;
+                has_entry = true;
             } else {
                 // Copy the path since find_entry_by_path calls config_get_value
                 // internally (via should_skip_entry), which clobbers the static buffer.
@@ -1892,6 +1893,7 @@ noreturn void _menu(bool first_run) {
                 find_entry_by_path(default_entry_path, menu_tree, 0, &found_entry, &found_index, true);
                 if (found_entry != NULL) {
                     selected_entry = found_index;
+                    has_entry = true;
                 }
             }
         }


### PR DESCRIPTION
Fixes #652.

On a dual-boot box `default_entry` stopped preselecting Windows: whatever was
booted last came up instead, so the machine booted Linux on the timeout.

The selection in `_menu` is a chain of `if (!has_entry)` steps.
`LoaderEntryOneShot` sets `has_entry` once it resolves an entry. The
`default_entry` block right below it sets `selected_entry` and leaves
`has_entry` alone - not in the index branch, not in the path branch. So the
next two blocks still see it false: `remember_last_entry` reads
`LimineLastBootedEntry` and overwrites the selection, and
`bli_get_default_entry` shadows it the same way. A numeric `default_entry`
goes through the same block, so switching to an index does not help either.

CONFIG.md documents the opposite, so this is a code bug and not a doc one:

> `remember_last_entry` and the persistent `LoaderEntryDefault` variable are
> consulted, in that order, only where this option is not set.

The patch sets `has_entry` in both branches, the way `LoaderEntryOneShot`
already does. The path branch only sets it once the path resolved, so an
unresolvable `default_entry` keeps falling through as before.

Built clean on trunk with `./configure --enable-uefi-x86-64
CC_FOR_TARGET=clang`, and again with `--enable-bios` since the block is not
UEFI-only; no new warnings. On the affected machine `remember_last_entry: no`
brings the preselection back, which is the workaround the issue describes.
