### PR TITLE
lib/elf: Preserve addends for undefined weak absolute relocations

### DIFF
--- a/common/lib/elf.c
+++ b/common/lib/elf.c
@@ -750,7 +750,7 @@ static bool elf64_apply_relocations(const struct elf64_reloc_state *st, uint8_t 
                 struct elf64_sym *s = (void *)elf + symtab_offset + sym_offset;
                 if (s->st_shndx == SHN_UNDEF) {
                     if ((s->st_info >> 4) == STB_WEAK) {
-                        reloc_store(ptr, 0);
+                        reloc_store(ptr, relocation->r_addend);
                         break;
                     }
                     if (strtab_size == 0) {


### PR DESCRIPTION
An ABS64 relocation against an undefined weak symbol currently writes zero even when its RELA addend is nonzero. Resolve the symbol to zero while retaining the addend, so an entry such as `weak_symbol + 7` produces `7`.

Validation: the actual relocation functions were exercised with real linked ELFs. Positive and negative weak-symbol addends fail before this change and pass afterwards; zero-addend and defined-symbol controls pass in both versions. The self-contained reproduction is in the linked issue. `./bootstrap`, `./configure --enable-werror --enable-all`, and `make all` passed with LLVM 22.1.8. No firmware boot test was performed.

Fixes #655.
