### PR TITLE
host/limine: Report failures saving uninstall data

### DIFF
--- a/host/limine.c
+++ b/host/limine.c
@@ -1785,7 +1785,9 @@ cleanup:
         fprintf(stderr, "Install failed, undoing work...\n");
         uninstall(true);
     } else if (uninstall_file != NULL) {
-        store_uninstall_data(uninstall_file);
+        if (!store_uninstall_data(uninstall_file)) {
+            ok = EXIT_FAILURE;
+        }
     }
 uninstall_mode_cleanup:
     free_uninstall_data();


### PR DESCRIPTION
When `--uninstall-data-file` cannot be saved, `bios-install` prints an error but exits successfully because it ignores `store_uninstall_data()`'s return value. Propagate that failure to the process exit status while retaining the existing cleanup and completed installation.

Validation: reproduced backup-open and backup-write failures with and without `--quiet`. All eight regression cases pass with the fix, including normal installation and a successful backup/uninstall roundtrip that restores the original image byte-for-byte. The standalone script is in the linked issue. The C99 host build and full LLVM build (`./bootstrap`, `./configure --enable-werror --enable-all`, `make all`) passed with warnings treated as errors.

Fixes #657.
