### PR TITLE
host/limine: Reject excess bios-install positional arguments

### DIFF
--- a/host/limine.c
+++ b/host/limine.c
@@ -1070,6 +1070,10 @@ static int bios_install(int argc, char *argv[]) {
             return EXIT_FAILURE;
         } else {
             if (device != NULL) { // [GPT partition index]
+                if (part_ndx != NULL) {
+                    bios_install_usage();
+                    goto uninstall_mode_cleanup;
+                }
                 part_ndx = argv[i]; // TODO: Make this non-positional?
             } else if ((device = fopen(argv[i], "r+b")) == NULL) { // <device>
                 perror_wrap("error: `%s`", argv[i]);


### PR DESCRIPTION
`bios-install disk.img 1 2` silently replaces the first partition index with the second and can install into the wrong GPT partition. Reject a second index operand before device initialization, using the existing cleanup path to close the opened device.

Validation: all 14 MBR/GPT regression cases pass. Nine malformed invocations, including interspersed options and quiet mode, now fail without changing the image; five valid controls preserve autodetection and explicit partition selection. The standalone regression is in the linked issue. The C99 host build and full LLVM build (`./bootstrap`, `./configure --enable-werror --enable-all`, `make all`) passed with warnings treated as errors.

Fixes #659.
